### PR TITLE
Add dedicated course page for reverse engineering program

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,7 +307,7 @@
             <svg viewBox="0 0 24 24" class="mt-1 h-5 w-5 text-slate-400"><path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </div>
         </a>
-        <a class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm hover:shadow-md transition-shadow dark:border-slate-700 dark:bg-slate-800 block focus:outline-none focus:ring-4 focus:ring-slate-200 dark:focus:ring-slate-700" href="#">
+        <a class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm hover:shadow-md transition-shadow dark:border-slate-700 dark:bg-slate-800 block focus:outline-none focus:ring-4 focus:ring-slate-200 dark:focus:ring-slate-700" href="reverse-additive.html">
           <div class="flex items-start justify-between gap-4">
             <div>
               <div class="flex items-center gap-3">

--- a/reverse-additive.html
+++ b/reverse-additive.html
@@ -1,0 +1,512 @@
+<!DOCTYPE html>
+<html lang="ru" class="scroll-smooth">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Step3D.Lab — Курс «Реверсивный инжиниринг и аддитивное производство»</title>
+  <meta name="description" content="Практический курс ДПО по реверсивному инжинирингу и аддитивному производству: 3D-сканирование, CAD, 3D-печать, календарно-тематический план и команда преподавателей технопарка РГСУ." />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><rect x='6' y='6' width='52' height='52' rx='12' fill='%230ea5e9'/><path d='M20 44V20l12-6 12 6v24l-12 6-12-6z M32 14v36' stroke='%23fff' stroke-width='2' fill='none'/></svg>">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = { theme: { extend: { boxShadow: { soft: '0 6px 30px rgba(15,23,42,.08)' } } } }
+  </script>
+  <style>
+    @keyframes floatY { 0%,100% { transform: translate(-50%,-50%) translateY(-10px) } 50% { transform: translate(-50%,-50%) translateY(10px) } }
+    @keyframes driftX { 0%,100% { transform: translateY(-50%) translateX(-12px) } 50% { transform: translateY(-50%) translateX(12px) } }
+    .glass { backdrop-filter: blur(8px) }
+    .active-link { background: rgb(15 23 42); color: white }
+    .dark .active-link { background: white; color: rgb(15 23 42) }
+  </style>
+</head>
+<body class="min-h-screen bg-gradient-to-b from-white to-slate-50 text-slate-800 dark:from-slate-900 dark:to-slate-950 dark:text-slate-100">
+  <div id="progress" class="fixed top-0 left-0 h-1 bg-slate-900/90 origin-left z-50" style="transform:scaleX(0);transform-origin:left"></div>
+
+  <header class="relative overflow-hidden">
+    <div class="absolute inset-0 pointer-events-none">
+      <div class="absolute -top-32 -right-24 h-80 w-80 rounded-full bg-sky-300/25 blur-3xl"></div>
+      <div class="absolute -bottom-32 -left-24 h-80 w-80 rounded-full bg-emerald-300/25 blur-3xl"></div>
+    </div>
+
+    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-16 md:pt-28 md:pb-20 relative z-10">
+      <nav class="mb-12" aria-label="Навигация по странице">
+        <div class="flex items-center justify-between gap-6">
+          <a href="index.html" class="flex items-center gap-3 font-semibold">
+            <svg viewBox="0 0 64 64" class="h-8 w-8" aria-hidden>
+              <defs><linearGradient id="logo" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0ea5e9"/><stop offset="1" stop-color="#22c55e"/></linearGradient></defs>
+              <rect x="6" y="6" width="52" height="52" rx="12" fill="url(#logo)"/>
+              <path d="M20 44V20l12-6 12 6v24l-12 6-12-6z M32 14v36" stroke="#fff" stroke-width="2" fill="none"/>
+            </svg>
+            Step3D.Lab
+          </a>
+          <div class="hidden md:flex items-center gap-1" id="links"></div>
+          <div class="md:hidden flex items-center gap-2">
+            <button id="themeToggleSm" class="rounded-xl border px-3 py-2 text-sm">🌙</button>
+            <button id="burger" aria-expanded="false" aria-label="Меню" class="rounded-xl border p-2">
+              <svg viewBox="0 0 24 24" class="h-5 w-5"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+            </button>
+          </div>
+        </div>
+        <div id="mobile" class="mt-3 grid gap-2 md:hidden hidden"></div>
+      </nav>
+
+      <div class="grid lg:grid-cols-[1.1fr,0.9fr] gap-10 md:gap-16 items-center" id="overview">
+        <div>
+          <span class="inline-flex items-center rounded-full border border-slate-200 dark:border-slate-700 px-3 py-1 text-xs uppercase tracking-wider text-slate-500 dark:text-slate-300">Курс ДПО · 48 часов</span>
+          <h1 class="mt-4 text-4xl md:text-5xl font-extrabold tracking-tight leading-tight">«Реверсивный инжиниринг и аддитивное производство»</h1>
+          <p class="mt-4 text-lg text-slate-600 dark:text-slate-300 max-w-prose">Интенсивное обучение для инженеров и технологов: оцифровка изделий, восстановление CAD‑моделей и изготовление оснастки и деталей с применением аддитивных технологий. Программа выстроена вокруг реальных задач промышленности и чемпионатов профессионального мастерства.</p>
+          <div class="mt-6 flex flex-wrap gap-3">
+            <button id="openModal" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-5 py-3 text-white font-medium shadow hover:bg-slate-800 focus:outline-none focus:ring-4 focus:ring-slate-300">Оставить заявку</button>
+            <a href="#schedule" class="inline-flex items-center gap-2 rounded-xl border border-slate-300 dark:border-slate-700 px-5 py-3 font-medium">Смотреть программу</a>
+          </div>
+          <div class="mt-6 rounded-3xl border border-slate-200 dark:border-slate-700 bg-white/80 dark:bg-slate-800/80 glass p-6 max-w-xl">
+            <h2 class="text-lg font-semibold">Фокус на производственный результат</h2>
+            <ul class="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc pl-5">
+              <li>Создание КД и 3D‑моделей по существующим деталям и агрегатам.</li>
+              <li>Оперативный ремонт и изготовление запчастей с применением аддитивных технологий.</li>
+              <li>Снижение издержек и брака за счёт самостоятельной разработки производственной оснастки.</li>
+            </ul>
+          </div>
+        </div>
+        <div class="relative aspect-square">
+          <div class="absolute inset-0 grid grid-cols-9 grid-rows-9 gap-1 opacity-25">
+            <script>
+              document.addEventListener('DOMContentLoaded',()=>{
+                const grid = document.currentScript.parentElement
+                const on = new Set([0,1,2,3,5,6,7,8,9,17,27,35,45,53,63,71,72,73,74,75,76,77,78,79,80])
+                for(let i=0;i<81;i++){
+                  const cell = document.createElement('div')
+                  cell.className = on.has(i) ? 'bg-slate-400/70' : 'bg-transparent'
+                  grid.appendChild(cell)
+                }
+              })
+            </script>
+          </div>
+          <div class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 animate-[floatY_6s_ease-in-out_infinite]">
+            <div class="size-24 md:size-28 rotate-45 bg-gradient-to-br from-slate-200 to-slate-400 dark:from-slate-600 dark:to-slate-800 rounded-[1.25rem] shadow-lg"></div>
+          </div>
+          <div class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 animate-[floatY_8s_ease-in-out_infinite]">
+            <div class="size-20 md:size-24 rotate-45 bg-gradient-to-br from-slate-200 to-slate-400 dark:from-slate-600 dark:to-slate-800 rounded-[1.25rem] shadow-lg"></div>
+          </div>
+          <div class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 animate-[floatY_10s_ease-in-out_infinite]">
+            <div class="size-16 md:size-20 rotate-45 bg-gradient-to-br from-slate-200 to-slate-400 dark:from-slate-600 dark:to-slate-800 rounded-[1.25rem] shadow-lg"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section id="focus" class="py-16 md:py-24">
+      <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h2 class="text-3xl md:text-4xl font-bold mb-6">Что получает участник курса</h2>
+        <div class="grid md:grid-cols-2 gap-6 md:gap-8">
+          <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+            <h3 class="text-lg font-semibold">Практика с оборудованием</h3>
+            <p class="mt-2 text-slate-600 dark:text-slate-300">3D‑сканеры RangeVision Spectrum, Artec Eva и FDM/DLP/SLA принтеры. Калибровка, настройка, контроль качества.</p>
+          </article>
+          <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+            <h3 class="text-lg font-semibold">Применение CAD и специализированного ПО</h3>
+            <p class="mt-2 text-slate-600 dark:text-slate-300">Geomagic Design X, GOM Inspect, Rhino, Autodesk Inventor, Fusion 360, Ultimaker Cura, CHITUBOX, Polygon X и др.</p>
+          </article>
+          <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+            <h3 class="text-lg font-semibold">Отработка полного цикла</h3>
+            <p class="mt-2 text-slate-600 dark:text-slate-300">От сканирования и обработки сеток до построения NURBS‑поверхностей, подготовки к печати и изготовления оснастки.</p>
+          </article>
+          <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+            <h3 class="text-lg font-semibold">Проектные задания чемпионатного уровня</h3>
+            <p class="mt-2 text-slate-600 dark:text-slate-300">Разбор кейсов WorldSkills, BRICS и Hi-Tech, тренировка по стандартам «Профессионалов» и отраслевых чемпионатов.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="modules" class="py-16 md:py-24 bg-white dark:bg-slate-900">
+      <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div aria-hidden class="mb-6 relative h-16 overflow-hidden rounded-2xl border border-slate-200 dark:border-slate-700 bg-gradient-to-r from-slate-50 to-slate-100 dark:from-slate-800 dark:to-slate-900">
+          <div class="absolute top-1/2 -translate-y-1/2 left-0 right-0 pointer-events-none">
+            <div class="flex gap-6 animate-[driftX_5s_ease-in-out_infinite]">
+              <div class="size-6 rotate-45 rounded-lg shadow bg-gradient-to-br from-slate-300 to-slate-500 dark:from-slate-600 dark:to-slate-800"></div>
+              <div class="size-6 rotate-45 rounded-lg shadow bg-gradient-to-br from-slate-300 to-slate-500 dark:from-slate-600 dark:to-slate-800"></div>
+              <div class="size-6 rotate-45 rounded-lg shadow bg-gradient-to-br from-slate-300 to-slate-500 dark:from-slate-600 dark:to-slate-800"></div>
+              <div class="size-6 rotate-45 rounded-lg shadow bg-gradient-to-br from-slate-300 to-slate-500 dark:from-slate-600 dark:to-slate-800"></div>
+              <div class="size-6 rotate-45 rounded-lg shadow bg-gradient-to-br from-slate-300 to-slate-500 dark:from-slate-600 dark:to-slate-800"></div>
+            </div>
+          </div>
+        </div>
+        <h2 class="text-3xl md:text-4xl font-bold mb-6">Практические блоки</h2>
+        <div class="grid lg:grid-cols-3 gap-6 md:gap-8">
+          <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+            <h3 class="text-lg font-semibold">3D‑сканирование</h3>
+            <ul class="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc pl-5">
+              <li>Выбор метода оцифровки и оснастки.</li>
+              <li>Калибровка и захват данных на стационарных и ручных сканерах.</li>
+              <li>Контроль качества облаков точек.</li>
+            </ul>
+          </article>
+          <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+            <h3 class="text-lg font-semibold">Реверсивный инжиниринг</h3>
+            <ul class="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc pl-5">
+              <li>Работа в Geomagic Design X (базовые и продвинутые функции).</li>
+              <li>Восстановление CAD‑геометрии сложных поверхностей.</li>
+              <li>Подготовка конструкторской документации.</li>
+            </ul>
+          </article>
+          <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+            <h3 class="text-lg font-semibold">Аддитивное производство</h3>
+            <ul class="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc pl-5">
+              <li>Подготовка моделей к 3D‑печати (FDM/DLP/SLA).</li>
+              <li>Изготовление мастер‑моделей и производственной оснастки.</li>
+              <li>Постобработка, бережливое производство, литьё в силикон.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="schedule" class="py-16 md:py-24">
+      <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h2 class="text-3xl md:text-4xl font-bold mb-6">Календарно-тематический план</h2>
+        <p class="text-slate-600 dark:text-slate-300 mb-6 max-w-3xl">Формат очного интенсива на 6 учебных дней (понедельник—суббота) по 8 академических часов. Каждому модулю соответствует практическая работа или мастер-класс с итоговым контролем.</p>
+        <div class="overflow-x-auto rounded-3xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900/40">
+          <table class="min-w-full divide-y divide-slate-200 dark:divide-slate-700 text-sm">
+            <thead class="bg-slate-100 dark:bg-slate-800/60 text-slate-600 dark:text-slate-300 uppercase tracking-wide text-xs">
+              <tr>
+                <th class="px-4 py-3 text-left font-medium">День</th>
+                <th class="px-4 py-3 text-left font-medium">Модуль / дисциплина</th>
+                <th class="px-4 py-3 text-left font-medium">Всего часов</th>
+                <th class="px-4 py-3 text-left font-medium">Лекции</th>
+                <th class="px-4 py-3 text-left font-medium">Практика</th>
+                <th class="px-4 py-3 text-left font-medium">Контроль</th>
+                <th class="px-4 py-3 text-left font-medium">Форма контроля</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-200 dark:divide-slate-800 text-slate-700 dark:text-slate-200">
+              <tr>
+                <td class="px-4 py-3 align-top font-semibold">01 · Пн</td>
+                <td class="px-4 py-3 space-y-2">
+                  <div><strong>Лекция.</strong> Реверсивный инжиниринг и технологии аддитивного производства. Опыт РГСУ и кейсы чемпионатов Hi-Tech. Охрана труда и техника безопасности.</div>
+                  <div><strong>Мастер-класс №1.</strong> CAD/CAM-моделирование мастер-моделей и метаформ для литья полимеров и выплавляемых моделей.</div>
+                  <div><strong>Практика №1.</strong> Выбор средства оцифровки и оснастки. Калибровка 3D-сканера (RangeVision Spectrum).</div>
+                  <div><strong>Практика №2.</strong> 3D-сканирование на стационарном сканере (RangeVision Spectrum).</div>
+                </td>
+                <td class="px-4 py-3">10</td>
+                <td class="px-4 py-3">1</td>
+                <td class="px-4 py-3">8.5</td>
+                <td class="px-4 py-3">0.5</td>
+                <td class="px-4 py-3">Устный опрос, зачёт</td>
+              </tr>
+              <tr class="bg-slate-50/60 dark:bg-slate-800/30">
+                <td class="px-4 py-3 align-top font-semibold">02 · Вт</td>
+                <td class="px-4 py-3 space-y-2">
+                  <div><strong>Практика №3.</strong> Реверсивный инжиниринг в Geomagic Design X (базовые функции).</div>
+                  <div><strong>Мастер-класс №2.</strong> Основы 3D-печати (FDM, оборудование PICASO 3D) от индустриального партнёра.</div>
+                  <div><strong>Практика №4.</strong> Подготовка моделей к 3D-печати по технологиям FDM/DLP/SLA. Запуск печати.</div>
+                </td>
+                <td class="px-4 py-3">8</td>
+                <td class="px-4 py-3">0.5</td>
+                <td class="px-4 py-3">6</td>
+                <td class="px-4 py-3">1.5</td>
+                <td class="px-4 py-3">Зачёт</td>
+              </tr>
+              <tr>
+                <td class="px-4 py-3 align-top font-semibold">03 · Ср</td>
+                <td class="px-4 py-3 space-y-2">
+                  <div><strong>Мастер-класс №3.</strong> 3D-сканирование ручным оптическим сканером (Artec Eva).</div>
+                  <div><strong>Практика №5.</strong> Реверсивный инжиниринг в Geomagic Design X (продвинутые функции).</div>
+                </td>
+                <td class="px-4 py-3">8</td>
+                <td class="px-4 py-3">1.5</td>
+                <td class="px-4 py-3">6</td>
+                <td class="px-4 py-3">0.5</td>
+                <td class="px-4 py-3">Устный опрос, зачёт</td>
+              </tr>
+              <tr class="bg-slate-50/60 dark:bg-slate-800/30">
+                <td class="px-4 py-3 align-top font-semibold">04 · Чт</td>
+                <td class="px-4 py-3 space-y-2">
+                  <div><strong>Мастер-класс №4.</strong> Основы 3D-печати по технологиям DLP/SLA (индустриальный партнёр).</div>
+                  <div><strong>Практика №6.</strong> Подготовка моделей к печати (FDM/DLP/SLA). Запуск печати.</div>
+                  <div><strong>Свободный практикум.</strong> Отработка навыков 3D-сканирования, реверсивного инжиниринга и 3D-печати.</div>
+                </td>
+                <td class="px-4 py-3">8</td>
+                <td class="px-4 py-3">1</td>
+                <td class="px-4 py-3">6.5</td>
+                <td class="px-4 py-3">0.5</td>
+                <td class="px-4 py-3">Устный опрос, зачёт</td>
+              </tr>
+              <tr>
+                <td class="px-4 py-3 align-top font-semibold">05 · Пт</td>
+                <td class="px-4 py-3 space-y-2">
+                  <div><strong>Чемпионатное задание.</strong> Выполнение задания формата International High-Tech Competition 2023 по компетенции «Реверсивный инжиниринг».</div>
+                </td>
+                <td class="px-4 py-3">16</td>
+                <td class="px-4 py-3">2</td>
+                <td class="px-4 py-3">12</td>
+                <td class="px-4 py-3">2</td>
+                <td class="px-4 py-3">Экзамен (демонстрационный)</td>
+              </tr>
+              <tr class="bg-slate-50/60 dark:bg-slate-800/30">
+                <td class="px-4 py-3 font-semibold">06 · Сб</td>
+                <td class="px-4 py-3">Резервный день и консультации по индивидуальным проектам.</td>
+                <td class="px-4 py-3">—</td>
+                <td class="px-4 py-3">—</td>
+                <td class="px-4 py-3">—</td>
+                <td class="px-4 py-3">—</td>
+                <td class="px-4 py-3">—</td>
+              </tr>
+              <tr>
+                <td class="px-4 py-3 font-semibold">Итого</td>
+                <td class="px-4 py-3">6 модулей, 4 мастер-класса, 6 практических работ, экзамен</td>
+                <td class="px-4 py-3">48 ч</td>
+                <td class="px-4 py-3">6</td>
+                <td class="px-4 py-3">32</td>
+                <td class="px-4 py-3">10</td>
+                <td class="px-4 py-3">Итоговый зачёт</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section id="format" class="py-16 md:py-24 bg-white dark:bg-slate-900">
+      <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h2 class="text-3xl md:text-4xl font-bold mb-6">Формат обучения</h2>
+        <div class="grid lg:grid-cols-2 gap-6 md:gap-10">
+          <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800 space-y-4">
+            <div>
+              <h3 class="text-lg font-semibold">Целевая аудитория</h3>
+              <ul class="mt-2 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc pl-5">
+                <li>Инженеры-конструкторы и технологи.</li>
+                <li>Операторы ЧПУ и специалисты по прототипированию.</li>
+                <li>Студенты технических вузов, молодые учёные и преподаватели.</li>
+                <li>Промышленные дизайнеры и разработчики изделий.</li>
+              </ul>
+            </div>
+            <div>
+              <h3 class="text-lg font-semibold">Параметры программы</h3>
+              <dl class="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-slate-600 dark:text-slate-300">
+                <div><dt class="font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide text-xs">Продолжительность</dt><dd class="mt-1 text-base">48 академических часов</dd></div>
+                <div><dt class="font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide text-xs">Группа</dt><dd class="mt-1 text-base">6–12 участников</dd></div>
+                <div><dt class="font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide text-xs">Режим</dt><dd class="mt-1 text-base">Интенсив 1 неделя, пн–сб, 09:00–18:00</dd></div>
+                <div><dt class="font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide text-xs">Стоимость</dt><dd class="mt-1 text-base">68 000 ₽ за участника</dd></div>
+                <div><dt class="font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide text-xs">Место</dt><dd class="mt-1 text-base">Москва, ул. Беговая, д. 12 (технопарк РГСУ)</dd></div>
+              </dl>
+            </div>
+          </div>
+          <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800 space-y-4">
+            <div>
+              <h3 class="text-lg font-semibold">Результаты обучения</h3>
+              <ul class="mt-2 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc pl-5">
+                <li>Навыки подготовки производства под задачи ремонтных служб и опытных цехов.</li>
+                <li>Компетенции по стандартам WorldSkills, BRICS и «Профессионалов».</li>
+                <li>Готовые кейсы по изготовлению оснастки, мастер-моделей, прототипов.</li>
+                <li>Удостоверение о повышении квалификации установленного образца.</li>
+              </ul>
+            </div>
+            <div>
+              <h3 class="text-lg font-semibold">Дополнительно</h3>
+              <ul class="mt-2 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc pl-5">
+                <li>Доступ к методическим материалам и видеолекциям преподавателей.</li>
+                <li>Индивидуальные консультации по внедрению аддитивных технологий.</li>
+                <li>Возможность продолжить обучение на курсах «Промышленный дизайн и инжиниринг» и «Инженерный дизайн (САПР)».</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="experts" class="py-16 md:py-24">
+      <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h2 class="text-3xl md:text-4xl font-bold mb-8">Команда курса</h2>
+        <div class="grid md:grid-cols-2 gap-6 md:gap-8">
+          <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+            <div class="flex flex-wrap items-start gap-4">
+              <div class="grid place-items-center rounded-2xl bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-100" style="width:64px;height:64px">АР</div>
+              <div class="flex-1 min-w-[220px]">
+                <h3 class="text-xl font-semibold">Алексей Валерьевич Рекут</h3>
+                <p class="mt-1 text-sm text-slate-500 dark:text-slate-300">Заместитель руководителя технопарка РГСУ, главный эксперт и тренер сборной России (WorldSkills, 2017–2022) по компетенции «Реверсивный инжиниринг».</p>
+                <ul class="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc pl-5">
+                  <li>Соавтор ФГОС СПО по аддитивным технологиям, разработчик компетенций WorldSkills.</li>
+                  <li>Эксперт по аддитивному производству, промышленному дизайну и прототипированию.</li>
+                  <li>Автор учебных пособий по Rhinoceros 3D; интервью на «Россия 24» и «Аддитивной кухне».</li>
+                </ul>
+              </div>
+            </div>
+          </article>
+          <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+            <div class="flex flex-wrap items-start gap-4">
+              <div class="grid place-items-center rounded-2xl bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-100" style="width:64px;height:64px">ВГ</div>
+              <div class="flex-1 min-w-[220px]">
+                <h3 class="text-xl font-semibold">Владимир Константинович Ганьшин</h3>
+                <p class="mt-1 text-sm text-slate-500 dark:text-slate-300">Руководитель технопарка РГСУ, тренер сборной России по реверсивному инжинирингу (2019–2021), преподаватель и разработчик программ ДПО.</p>
+                <ul class="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc pl-5">
+                  <li>Опыт подготовки чемпионов WorldSkills и BRICS, экспертиза в САПР и внедрении ЧПУ.</li>
+                  <li>Преподаватель курсов «Промышленный дизайн и инжиниринг», «Инженерный дизайн (САПР)».</li>
+                  <li>Автор видеолекций по методологии технического образования, наставник ИТ-классов.</li>
+                </ul>
+              </div>
+            </div>
+          </article>
+          <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+            <div class="flex flex-wrap items-start gap-4">
+              <div class="grid place-items-center rounded-2xl bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-100" style="width:64px;height:64px">ХП</div>
+              <div class="flex-1 min-w-[220px]">
+                <h3 class="text-xl font-semibold">Христина Анатольевна Понкратова</h3>
+                <p class="mt-1 text-sm text-slate-500 dark:text-slate-300">Учебный мастер технопарка РГСУ, чемпионка WorldSkills Russia и BRICS Skills Challenge по реверсивному инжинирингу.</p>
+                <ul class="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc pl-5">
+                  <li>Специалист по биопротезированию, аддитивному производству и инженерному дизайну.</li>
+                  <li>Опыт подготовки школьных и корпоративных команд (Ростех, Сибур, Роскосмос, Северсталь).</li>
+                  <li>Лауреат гранта Правительства Москвы в сфере образования (2024).</li>
+                </ul>
+              </div>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="contacts" class="py-16 md:py-24 bg-white dark:bg-slate-900 border-t border-slate-200 dark:border-slate-800">
+      <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="grid md:grid-cols-2 gap-10 items-start">
+          <div>
+            <h2 class="text-3xl md:text-4xl font-bold">Как записаться</h2>
+            <p class="mt-3 text-slate-600 dark:text-slate-300">Оставьте заявку через форму или напишите нам — подскажем, как адаптировать программу под ваш запрос и подготовим договор на обучение.</p>
+            <div class="mt-6 flex flex-wrap gap-3">
+              <button class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-5 py-3 text-white font-medium shadow hover:bg-slate-800 focus:outline-none focus:ring-4 focus:ring-slate-300" id="openModal2">Оставить заявку</button>
+              <a href="mailto:projects.step3d@gmail.com" class="inline-flex items-center gap-2 rounded-xl bg-white dark:bg-slate-800 px-5 py-3 border border-slate-200 dark:border-slate-700 font-medium shadow-sm hover:shadow focus:outline-none focus:ring-4 focus:ring-slate-200 dark:focus:ring-slate-700">projects.step3d@gmail.com</a>
+              <a href="https://t.me/step_3d_mngr" target="_blank" rel="noreferrer" class="inline-flex items-center gap-2 rounded-xl bg-white dark:bg-slate-800 px-5 py-3 border border-slate-200 dark:border-slate-700 font-medium shadow-sm hover:shadow focus:outline-none focus:ring-4 focus:ring-slate-200 dark:focus:ring-slate-700">Telegram</a>
+            </div>
+          </div>
+          <div class="rounded-3xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-soft space-y-4">
+            <div>
+              <h3 class="text-lg font-semibold">Организационная информация</h3>
+              <ul class="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc pl-5">
+                <li>Площадка: технопарк РГСУ, Москва, ул. Беговая, д. 12.</li>
+                <li>Документ об обучении: удостоверение о повышении квалификации установленного образца.</li>
+                <li>Необходимые навыки: базовый уровень владения CAD, уверенный ПК.</li>
+                <li>Рекомендуемая одежда: закрытая обувь, удобная форма для работы в мастерских.</li>
+              </ul>
+            </div>
+            <div>
+              <h3 class="text-lg font-semibold">Связанные программы</h3>
+              <ul class="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc pl-5">
+                <li><a class="hover:underline" href="index.html#courses">Промышленный дизайн и инжиниринг (72 ч)</a></li>
+                <li><a class="hover:underline" href="index.html#courses">Инженерный дизайн (САПР)</a></li>
+              </ul>
+            </div>
+            <div class="text-sm text-slate-500 dark:text-slate-400">© <span id="y"></span> Step3D.Lab · Технопарк РГСУ</div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <div id="modal" class="fixed inset-0 bg-slate-900/60 backdrop-blur-sm hidden z-50">
+    <div id="modalBg" class="absolute inset-0"></div>
+    <div class="relative max-w-lg mx-auto mt-24 bg-white dark:bg-slate-900 rounded-3xl shadow-soft p-8">
+      <div class="flex items-center justify-between gap-3">
+        <h2 class="text-2xl font-semibold">Заявка на курс</h2>
+        <button id="closeModal" class="rounded-xl border border-slate-200 dark:border-slate-700 px-3 py-1">✕</button>
+      </div>
+      <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">Заполните форму, и мы свяжемся с вами для уточнения деталей обучения.</p>
+      <form id="requestForm" class="mt-6 space-y-4">
+        <label class="block text-sm font-medium text-slate-600 dark:text-slate-300">Имя<input required name="name" type="text" class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2" /></label>
+        <label class="block text-sm font-medium text-slate-600 dark:text-slate-300">E-mail<input required name="email" type="email" class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2" /></label>
+        <label class="block text-sm font-medium text-slate-600 dark:text-slate-300">Телефон<input name="phone" type="tel" class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2" /></label>
+        <label class="block text-sm font-medium text-slate-600 dark:text-slate-300">Комментарий<textarea name="comment" rows="3" class="mt-1 w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2"></textarea></label>
+        <input type="hidden" name="course" value="Реверсивный инжиниринг и аддитивное производство" />
+        <button type="submit" class="w-full rounded-xl bg-slate-900 text-white py-3 font-medium hover:bg-slate-800">Отправить</button>
+      </form>
+    </div>
+  </div>
+
+  <div id="nav-data" class="hidden" data-nav='[{"id":"overview","label":"О курсе"},{"id":"focus","label":"Фокус"},{"id":"modules","label":"Модули"},{"id":"schedule","label":"План"},{"id":"format","label":"Формат"},{"id":"experts","label":"Команда"},{"id":"contacts","label":"Контакты"}]'></div>
+
+  <script>
+    const root = document.documentElement
+    const stored = localStorage.getItem('step3d-theme')
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+    const initial = stored || (prefersDark ? 'dark' : 'light')
+    if(initial === 'dark') root.classList.add('dark')
+    function setTheme(mode){
+      if(mode === 'dark'){ root.classList.add('dark'); localStorage.setItem('step3d-theme','dark') }
+      else { root.classList.remove('dark'); localStorage.setItem('step3d-theme','light') }
+      document.querySelectorAll('#themeToggle, #themeToggleSm').forEach(btn=>{
+        if(btn) btn.textContent = root.classList.contains('dark') ? '☀️' : '🌙'
+      })
+    }
+
+    const themeToggle = document.getElementById('themeToggle')
+    const themeToggleSm = document.getElementById('themeToggleSm')
+    ;[themeToggle, themeToggleSm].forEach(btn=> btn && btn.addEventListener('click', ()=> setTheme(root.classList.contains('dark') ? 'light' : 'dark')))
+
+    const navData = JSON.parse(document.getElementById('nav-data').dataset.nav)
+    const linksWrap = document.getElementById('links')
+    const mobileWrap = document.getElementById('mobile')
+    const burger = document.getElementById('burger')
+
+    function renderLinks(container, variant){
+      container.innerHTML = ''
+      navData.forEach(({id,label})=>{
+        const a = document.createElement('a')
+        a.href = `#${id}`
+        a.textContent = label
+        a.className = variant==='desktop' ? 'px-3 py-2 rounded-xl text-sm font-medium hover:bg-slate-100 dark:hover:bg-slate-800' : 'px-3 py-2 rounded-xl text-sm font-medium border bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700'
+        container.appendChild(a)
+      })
+      if(variant==='desktop'){
+        const tBtn = document.createElement('button')
+        tBtn.className = 'ml-2 rounded-xl border px-3 py-2 text-sm'
+        tBtn.textContent = root.classList.contains('dark') ? 'Светлая' : 'Тёмная'
+        tBtn.addEventListener('click', ()=>{ setTheme(root.classList.contains('dark') ? 'light':'dark'); tBtn.textContent = root.classList.contains('dark') ? 'Светлая' : 'Тёмная' })
+        container.appendChild(tBtn)
+      }
+    }
+    renderLinks(linksWrap, 'desktop')
+    renderLinks(mobileWrap, 'mobile')
+    burger && burger.addEventListener('click', ()=>{
+      const opened = !mobileWrap.classList.contains('hidden')
+      burger.setAttribute('aria-expanded', String(!opened))
+      mobileWrap.classList.toggle('hidden')
+    })
+
+    const sectionIds = navData.map(n=> n.id)
+    const anchors = Array.from(document.querySelectorAll('#links a'))
+    const mobAnchors = Array.from(document.querySelectorAll('#mobile a'))
+    const obs = new IntersectionObserver(entries=>{
+      const vis = entries.filter(e=> e.isIntersecting).sort((a,b)=> b.intersectionRatio - a.intersectionRatio)[0]
+      if(!vis) return
+      const id = vis.target.id
+      ;[...anchors, ...mobAnchors].forEach(a=> a.classList.toggle('active-link', a.getAttribute('href')===`#${id}`))
+    }, {rootMargin:'-40% 0px -55% 0px', threshold:[0,0.25,0.5,0.75,1]})
+    sectionIds.forEach(id=>{ const el = document.getElementById(id); if(el) obs.observe(el) })
+
+    const progress = document.getElementById('progress')
+    document.addEventListener('scroll', ()=>{
+      const h = document.documentElement
+      const sc = h.scrollTop / (h.scrollHeight - h.clientHeight)
+      progress.style.transform = `scaleX(${sc})`
+    })
+
+    const modal = document.getElementById('modal')
+    const openModal = ()=> modal.classList.remove('hidden')
+    const closeModal = ()=> modal.classList.add('hidden')
+    document.getElementById('openModal')?.addEventListener('click', openModal)
+    document.getElementById('openModal2')?.addEventListener('click', openModal)
+    document.getElementById('closeModal')?.addEventListener('click', closeModal)
+    document.getElementById('modalBg')?.addEventListener('click', closeModal)
+    document.addEventListener('keydown', (e)=>{ if(e.key==='Escape' && !modal.classList.contains('hidden')) closeModal() })
+    document.getElementById('requestForm')?.addEventListener('submit', (e)=>{
+      e.preventDefault()
+      const fd = new FormData(e.target)
+      console.log('[Request]', Object.fromEntries(fd.entries()))
+      closeModal()
+      alert('Заявка отправлена! (демо)')
+    })
+
+    const y = new Date().getFullYear()
+    document.getElementById('y').textContent = y
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone page in the existing Step3D.Lab style for the course «Реверсивный инжиниринг и аддитивное производство»
- include sections for benefits, practical modules, the detailed calendar plan, format details, instructors, and contacts with a CTA form
- link the course card on the main page to the new detailed page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3d1f76a448333b3150c32555da2d1