### PR TITLE
Update partner cards and share button behaviour

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,7 +361,7 @@
           </div>
         </div>
         <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800 flex items-center gap-4">
-
+          <div class="grid place-items-center rounded-2xl bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-100" style="width:64px;height:64px">TP</div>
           <div>
             <div class="font-semibold">Технопарк РГСУ</div>
             <div class="text-sm text-slate-500 dark:text-slate-300">ресурсная база</div>
@@ -370,7 +370,7 @@
         <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800 flex items-center gap-4">
           <div class="grid place-items-center rounded-2xl bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-100" style="width:64px;height:64px">РГ</div>
           <div>
-
+            <div class="font-semibold">Российский государственный университет</div>
             <div class="text-sm text-slate-500 dark:text-slate-300">образовательный партнёр</div>
           </div>
         </div>
@@ -567,7 +567,22 @@
     }))
 
     // ===== Поделиться ссылкой
-
+    document.getElementById('shareLink')?.addEventListener('click', async ()=>{
+      const url = window.location.href
+      const title = document.title
+      if(navigator.share){
+        try {
+          await navigator.share({ title, url })
+        } catch (err) {
+          if(err?.name !== 'AbortError') alert('Не удалось поделиться ссылкой. Попробуйте ещё раз.')
+        }
+        return
+      }
+      try {
+        await navigator.clipboard.writeText(url)
+        alert('Ссылка скопирована в буфер обмена')
+      } catch (err) {
+        prompt('Скопируйте ссылку вручную:', url)
       }
     })
 


### PR DESCRIPTION
## Summary
- add partner cards for Step3D, Technopark RGSU, and Russian State University in the team section with consistent styling
- replace the event export control with a share link button and implement share/copy logic
- update the Telegram contact link text to "Написать нам в телеграм" pointing to @step_3d_mngr

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d3d3831e1083338d3d72cadd6dd492