### PR TITLE
Add placeholder image assets and wire them into pages

### DIFF
--- a/assets/images/index/projects/heritage/slide-1.svg
+++ b/assets/images/index/projects/heritage/slide-1.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450">
+  <defs>
+    <linearGradient id="heritage1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f172a" />
+      <stop offset="1" stop-color="#1e293b" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#heritage1)" rx="32" />
+  <text x="50%" y="44%" text-anchor="middle" fill="#e2e8f0" font-size="38" font-family="'Segoe UI',sans-serif">ОКН · фото 1</text>
+  <text x="50%" y="62%" text-anchor="middle" fill="#cbd5f5" font-size="18" font-family="'Segoe UI',sans-serif">Добавьте сюда изображение экспоната</text>
+</svg>

--- a/assets/images/index/projects/heritage/slide-2.svg
+++ b/assets/images/index/projects/heritage/slide-2.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450">
+  <defs>
+    <linearGradient id="heritage2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f172a" />
+      <stop offset="1" stop-color="#1e293b" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#heritage2)" rx="32" />
+  <text x="50%" y="44%" text-anchor="middle" fill="#e2e8f0" font-size="38" font-family="'Segoe UI',sans-serif">ОКН · фото 2</text>
+  <text x="50%" y="62%" text-anchor="middle" fill="#cbd5f5" font-size="18" font-family="'Segoe UI',sans-serif">Добавьте сюда изображение экспоната</text>
+</svg>

--- a/assets/images/index/projects/orthosis/slide-1.svg
+++ b/assets/images/index/projects/orthosis/slide-1.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0ea5e9" />
+      <stop offset="1" stop-color="#22c55e" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#g)" rx="32" />
+  <text x="50%" y="44%" text-anchor="middle" fill="#ffffff" font-size="40" font-family="'Segoe UI',sans-serif">Ортез · фото 1</text>
+  <text x="50%" y="62%" text-anchor="middle" fill="#ecfeff" font-size="20" font-family="'Segoe UI',sans-serif">Замените файлом с проектом</text>
+</svg>

--- a/assets/images/index/projects/orthosis/slide-2.svg
+++ b/assets/images/index/projects/orthosis/slide-2.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#22c55e" />
+      <stop offset="1" stop-color="#0ea5e9" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#g)" rx="32" />
+  <text x="50%" y="44%" text-anchor="middle" fill="#ffffff" font-size="40" font-family="'Segoe UI',sans-serif">Ортез · фото 2</text>
+  <text x="50%" y="62%" text-anchor="middle" fill="#ecfeff" font-size="20" font-family="'Segoe UI',sans-serif">Положите сюда изображение проекта</text>
+</svg>

--- a/assets/images/index/projects/orthosis/slide-3.svg
+++ b/assets/images/index/projects/orthosis/slide-3.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0ea5e9" />
+      <stop offset="1" stop-color="#22c55e" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#g)" rx="32" />
+  <text x="50%" y="44%" text-anchor="middle" fill="#ffffff" font-size="40" font-family="'Segoe UI',sans-serif">Ортез · фото 3</text>
+  <text x="50%" y="62%" text-anchor="middle" fill="#ecfeff" font-size="20" font-family="'Segoe UI',sans-serif">Замените файлом с проектом</text>
+</svg>

--- a/assets/images/index/team/alexey-rekut.svg
+++ b/assets/images/index/team/alexey-rekut.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="portraitAR" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6366f1" />
+      <stop offset="1" stop-color="#14b8a6" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="56" fill="url(#portraitAR)" />
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" fill="#ffffff" font-size="140" font-family="'Segoe UI',sans-serif" font-weight="700">АР</text>
+  <text x="50%" y="82%" text-anchor="middle" fill="#e0f2fe" font-size="28" font-family="'Segoe UI',sans-serif">Алексей Рекут</text>
+  <text x="50%" y="90%" text-anchor="middle" fill="#cbd5f5" font-size="20" font-family="'Segoe UI',sans-serif">Замените на фото</text>
+</svg>

--- a/assets/images/index/team/anna-ponkratova.svg
+++ b/assets/images/index/team/anna-ponkratova.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="portraitAP" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f97316" />
+      <stop offset="1" stop-color="#facc15" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="56" fill="url(#portraitAP)" />
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" fill="#ffffff" font-size="140" font-family="'Segoe UI',sans-serif" font-weight="700">АП</text>
+  <text x="50%" y="82%" text-anchor="middle" fill="#fff7ed" font-size="28" font-family="'Segoe UI',sans-serif">Анна Понкратова</text>
+  <text x="50%" y="90%" text-anchor="middle" fill="#fde68a" font-size="20" font-family="'Segoe UI',sans-serif">Замените на фото</text>
+</svg>

--- a/assets/images/index/team/rgsu.svg
+++ b/assets/images/index/team/rgsu.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="portraitRGSU" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#9333ea" />
+      <stop offset="1" stop-color="#22d3ee" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="56" fill="url(#portraitRGSU)" />
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" fill="#ffffff" font-size="120" font-family="'Segoe UI',sans-serif" font-weight="700">РГСУ</text>
+  <text x="50%" y="82%" text-anchor="middle" fill="#fdf4ff" font-size="24" font-family="'Segoe UI',sans-serif">Образовательный партнёр</text>
+  <text x="50%" y="90%" text-anchor="middle" fill="#f5d0fe" font-size="20" font-family="'Segoe UI',sans-serif">Замените логотипом</text>
+</svg>

--- a/assets/images/index/team/step3d.svg
+++ b/assets/images/index/team/step3d.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="portraitS3" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1e293b" />
+      <stop offset="1" stop-color="#0ea5e9" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="56" fill="url(#portraitS3)" />
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" fill="#ffffff" font-size="120" font-family="'Segoe UI',sans-serif" font-weight="700">STEP3D</text>
+  <text x="50%" y="82%" text-anchor="middle" fill="#dbeafe" font-size="26" font-family="'Segoe UI',sans-serif">Индустриальный партнёр</text>
+  <text x="50%" y="90%" text-anchor="middle" fill="#bae6fd" font-size="20" font-family="'Segoe UI',sans-serif">Замените логотипом</text>
+</svg>

--- a/assets/images/index/team/technopark-rgsu.svg
+++ b/assets/images/index/team/technopark-rgsu.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="portraitTP" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f172a" />
+      <stop offset="1" stop-color="#1e293b" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="56" fill="url(#portraitTP)" />
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" fill="#38bdf8" font-size="70" font-family="'Segoe UI',sans-serif" font-weight="700">ТЕХНОПАРК</text>
+  <text x="50%" y="63%" text-anchor="middle" fill="#38bdf8" font-size="48" font-family="'Segoe UI',sans-serif" font-weight="600">РГСУ</text>
+  <text x="50%" y="82%" text-anchor="middle" fill="#94a3b8" font-size="24" font-family="'Segoe UI',sans-serif">Ресурсная база</text>
+  <text x="50%" y="90%" text-anchor="middle" fill="#cbd5f5" font-size="20" font-family="'Segoe UI',sans-serif">Замените логотипом</text>
+</svg>

--- a/assets/images/index/team/vladimir-ganishin.svg
+++ b/assets/images/index/team/vladimir-ganishin.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="portraitVG" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0ea5e9" />
+      <stop offset="1" stop-color="#22c55e" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="56" fill="url(#portraitVG)" />
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" fill="#ffffff" font-size="140" font-family="'Segoe UI',sans-serif" font-weight="700">ВГ</text>
+  <text x="50%" y="82%" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="'Segoe UI',sans-serif">Владимир Ганьшин</text>
+  <text x="50%" y="90%" text-anchor="middle" fill="#e2f8ff" font-size="20" font-family="'Segoe UI',sans-serif">Замените на фото</text>
+</svg>

--- a/assets/images/reverse-additive/experts/khristina-ponkratova.svg
+++ b/assets/images/reverse-additive/experts/khristina-ponkratova.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="portraitKP" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#fb7185" />
+      <stop offset="1" stop-color="#f472b6" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="56" fill="url(#portraitKP)" />
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" fill="#ffffff" font-size="120" font-family="'Segoe UI',sans-serif" font-weight="700">ХП</text>
+  <text x="50%" y="82%" text-anchor="middle" fill="#ffe4e6" font-size="26" font-family="'Segoe UI',sans-serif">Христина Понкратова</text>
+  <text x="50%" y="90%" text-anchor="middle" fill="#fecdd3" font-size="20" font-family="'Segoe UI',sans-serif">Замените на фото</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -236,9 +236,15 @@
           </div>
           <div class="mt-4 rounded-2xl overflow-hidden border border-slate-200 dark:border-slate-700">
             <div class="aspect-video grid">
-              <div class="slide flex items-center justify-center bg-gradient-to-br from-slate-100 to-slate-200 text-slate-600">Ортез · фото 1</div>
-              <div class="slide hidden items-center justify-center bg-gradient-to-br from-slate-100 to-slate-200 text-slate-600">Ортез · фото 2</div>
-              <div class="slide hidden items-center justify-center bg-gradient-to-br from-slate-100 to-slate-200 text-slate-600">Ортез · фото 3</div>
+              <div class="slide">
+                <img src="assets/images/index/projects/orthosis/slide-1.svg" alt="Проект ортеза — фото 1" class="h-full w-full object-cover" loading="lazy" />
+              </div>
+              <div class="slide hidden">
+                <img src="assets/images/index/projects/orthosis/slide-2.svg" alt="Проект ортеза — фото 2" class="h-full w-full object-cover" loading="lazy" />
+              </div>
+              <div class="slide hidden">
+                <img src="assets/images/index/projects/orthosis/slide-3.svg" alt="Проект ортеза — фото 3" class="h-full w-full object-cover" loading="lazy" />
+              </div>
             </div>
             <div class="flex items-center justify-between p-2">
               <button class="rounded-lg border px-3 py-1 text-sm js-prev">◀</button>
@@ -252,8 +258,12 @@
           <p class="mt-1 text-slate-600 dark:text-slate-300 text-sm">Сканирование и восстановление геометрии, подготовка экспозиционных макетов.</p>
           <div class="mt-4 rounded-2xl overflow-hidden border border-slate-200 dark:border-slate-700">
             <div class="aspect-video grid">
-              <div class="slide flex items-center justify-center bg-gradient-to-br from-slate-100 to-slate-200 text-slate-600">ОКН · фото 1</div>
-              <div class="slide hidden items-center justify-center bg-gradient-to-br from-slate-100 to-slate-200 text-slate-600">ОКН · фото 2</div>
+              <div class="slide">
+                <img src="assets/images/index/projects/heritage/slide-1.svg" alt="Оцифровка объектов культурного наследия — фото 1" class="h-full w-full object-cover" loading="lazy" />
+              </div>
+              <div class="slide hidden">
+                <img src="assets/images/index/projects/heritage/slide-2.svg" alt="Оцифровка объектов культурного наследия — фото 2" class="h-full w-full object-cover" loading="lazy" />
+              </div>
             </div>
             <div class="flex items-center justify-between p-2">
               <button class="rounded-lg border px-3 py-1 text-sm js-prev">◀</button>
@@ -330,7 +340,7 @@
       <h2 class="text-3xl md:text-4xl font-bold mb-6">Команда</h2>
       <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
         <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800 flex items-center gap-4">
-          <div class="grid place-items-center rounded-2xl bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-100" style="width:64px;height:64px">ВГ</div>
+          <img src="assets/images/index/team/vladimir-ganishin.svg" alt="Владимир Ганьшин" class="h-16 w-16 rounded-2xl border border-slate-200 object-cover shadow-sm dark:border-slate-600" loading="lazy" />
           <div>
             <div class="font-semibold">Владимир Ганьшин</div>
             <div class="text-sm text-slate-500 dark:text-slate-300">руководитель лаборатории</div>
@@ -338,7 +348,7 @@
           </div>
         </div>
         <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800 flex items-center gap-4">
-          <div class="grid place-items-center rounded-2xl bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-100" style="width:64px;height:64px">АП</div>
+          <img src="assets/images/index/team/anna-ponkratova.svg" alt="Анна Понкратова" class="h-16 w-16 rounded-2xl border border-slate-200 object-cover shadow-sm dark:border-slate-600" loading="lazy" />
           <div>
             <div class="font-semibold">Анна Понкратова</div>
             <div class="text-sm text-slate-500 dark:text-slate-300">ведущий инженер‑преподаватель</div>
@@ -346,7 +356,7 @@
           </div>
         </div>
         <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800 flex items-center gap-4">
-          <div class="grid place-items-center rounded-2xl bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-100" style="width:64px;height:64px">АР</div>
+          <img src="assets/images/index/team/alexey-rekut.svg" alt="Алексей Рекут" class="h-16 w-16 rounded-2xl border border-slate-200 object-cover shadow-sm dark:border-slate-600" loading="lazy" />
           <div>
             <div class="font-semibold">Алексей Рекут</div>
             <div class="text-sm text-slate-500 dark:text-slate-300">инженер‑конструктор</div>
@@ -354,23 +364,23 @@
           </div>
         </div>
         <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800 flex items-center gap-4">
-          <div class="grid place-items-center rounded-2xl bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-100" style="width:64px;height:64px">S3</div>
+          <img src="assets/images/index/team/step3d.svg" alt="Step3D" class="h-16 w-16 rounded-2xl border border-slate-200 bg-white object-contain p-1 shadow-sm dark:border-slate-600 dark:bg-slate-900" loading="lazy" />
           <div>
             <div class="font-semibold">Step3D</div>
             <div class="text-sm text-slate-500 dark:text-slate-300">индустриальный партнёр лаборатории</div>
           </div>
         </div>
         <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800 flex items-center gap-4">
-
+          <img src="assets/images/index/team/technopark-rgsu.svg" alt="Технопарк РГСУ" class="h-16 w-16 rounded-2xl border border-slate-200 bg-white object-contain p-1 shadow-sm dark:border-slate-600 dark:bg-slate-900" loading="lazy" />
           <div>
             <div class="font-semibold">Технопарк РГСУ</div>
             <div class="text-sm text-slate-500 dark:text-slate-300">ресурсная база</div>
           </div>
         </div>
         <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800 flex items-center gap-4">
-          <div class="grid place-items-center rounded-2xl bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-100" style="width:64px;height:64px">РГ</div>
+          <img src="assets/images/index/team/rgsu.svg" alt="РГСУ" class="h-16 w-16 rounded-2xl border border-slate-200 bg-white object-contain p-1 shadow-sm dark:border-slate-600 dark:bg-slate-900" loading="lazy" />
           <div>
-
+            <div class="font-semibold">РГСУ</div>
             <div class="text-sm text-slate-500 dark:text-slate-300">образовательный партнёр</div>
           </div>
         </div>

--- a/reverse-additive.html
+++ b/reverse-additive.html
@@ -322,7 +322,7 @@
         <div class="grid md:grid-cols-2 gap-6 md:gap-8">
           <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
             <div class="flex flex-wrap items-start gap-4">
-              <div class="grid place-items-center rounded-2xl bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-100" style="width:64px;height:64px">АР</div>
+              <img src="assets/images/index/team/alexey-rekut.svg" alt="Алексей Валерьевич Рекут" class="h-16 w-16 rounded-2xl border border-slate-200 object-cover shadow-sm dark:border-slate-600" loading="lazy" />
               <div class="flex-1 min-w-[220px]">
                 <h3 class="text-xl font-semibold">Алексей Валерьевич Рекут</h3>
                 <p class="mt-1 text-sm text-slate-500 dark:text-slate-300">Заместитель руководителя технопарка РГСУ, главный эксперт и тренер сборной России (WorldSkills, 2017–2022) по компетенции «Реверсивный инжиниринг».</p>
@@ -336,7 +336,7 @@
           </article>
           <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
             <div class="flex flex-wrap items-start gap-4">
-              <div class="grid place-items-center rounded-2xl bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-100" style="width:64px;height:64px">ВГ</div>
+              <img src="assets/images/index/team/vladimir-ganishin.svg" alt="Владимир Константинович Ганьшин" class="h-16 w-16 rounded-2xl border border-slate-200 object-cover shadow-sm dark:border-slate-600" loading="lazy" />
               <div class="flex-1 min-w-[220px]">
                 <h3 class="text-xl font-semibold">Владимир Константинович Ганьшин</h3>
                 <p class="mt-1 text-sm text-slate-500 dark:text-slate-300">Руководитель технопарка РГСУ, тренер сборной России по реверсивному инжинирингу (2019–2021), преподаватель и разработчик программ ДПО.</p>
@@ -350,7 +350,7 @@
           </article>
           <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
             <div class="flex flex-wrap items-start gap-4">
-              <div class="grid place-items-center rounded-2xl bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-100" style="width:64px;height:64px">ХП</div>
+              <img src="assets/images/reverse-additive/experts/khristina-ponkratova.svg" alt="Христина Анатольевна Понкратова" class="h-16 w-16 rounded-2xl border border-slate-200 object-cover shadow-sm dark:border-slate-600" loading="lazy" />
               <div class="flex-1 min-w-[220px]">
                 <h3 class="text-xl font-semibold">Христина Анатольевна Понкратова</h3>
                 <p class="mt-1 text-sm text-slate-500 dark:text-slate-300">Учебный мастер технопарка РГСУ, чемпионка WorldSkills Russia и BRICS Skills Challenge по реверсивному инжинирингу.</p>


### PR DESCRIPTION
## Summary
- add structured image folders with placeholder SVGs for projects and team members
- update the homepage project gallery and team section to use the new image assets
- show team portraits on the course page using the shared placeholders

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3d3d3762883338229f2d6e616e738