### PR TITLE
Add shared footer to course page

### DIFF
--- a/reverse-additive.html
+++ b/reverse-additive.html
@@ -366,40 +366,55 @@
       </div>
     </section>
 
-    <section id="contacts" class="py-16 md:py-24 bg-white dark:bg-slate-900 border-t border-slate-200 dark:border-slate-800">
-      <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="grid md:grid-cols-2 gap-10 items-start">
+    <footer id="contacts" class="py-16 md:py-24 border-t border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="grid md:grid-cols-2 gap-10 items-center">
           <div>
-            <h2 class="text-3xl md:text-4xl font-bold">Как записаться</h2>
-            <p class="mt-3 text-slate-600 dark:text-slate-300">Оставьте заявку через форму или напишите нам — подскажем, как адаптировать программу под ваш запрос и подготовим договор на обучение.</p>
+            <h2 class="text-3xl md:text-4xl font-bold">Контакты</h2>
+            <p class="mt-3 text-slate-600 dark:text-slate-300 max-w-prose">Задайте вопрос или оставьте заявку — поможем выбрать формат: учебный модуль, проект, НИОКР или услугу.</p>
             <div class="mt-6 flex flex-wrap gap-3">
               <button class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-5 py-3 text-white font-medium shadow hover:bg-slate-800 focus:outline-none focus:ring-4 focus:ring-slate-300" id="openModal2">Оставить заявку</button>
-              <a href="mailto:projects.step3d@gmail.com" class="inline-flex items-center gap-2 rounded-xl bg-white dark:bg-slate-800 px-5 py-3 border border-slate-200 dark:border-slate-700 font-medium shadow-sm hover:shadow focus:outline-none focus:ring-4 focus:ring-slate-200 dark:focus:ring-slate-700">projects.step3d@gmail.com</a>
-              <a href="https://t.me/step_3d_mngr" target="_blank" rel="noreferrer" class="inline-flex items-center gap-2 rounded-xl bg-white dark:bg-slate-800 px-5 py-3 border border-slate-200 dark:border-slate-700 font-medium shadow-sm hover:shadow focus:outline-none focus:ring-4 focus:ring-slate-200 dark:focus:ring-slate-700">Telegram</a>
+              <a href="https://t.me/step_3d_mngr" target="_blank" rel="noreferrer" class="inline-flex items-center gap-2 rounded-xl bg-white dark:bg-slate-800 px-5 py-3 border border-slate-200 dark:border-slate-700 font-medium shadow-sm hover:shadow focus:outline-none focus:ring-4 focus:ring-slate-200 dark:focus:ring-slate-700">Написать нам в телеграм</a>
+              <button id="shareLink" class="inline-flex items-center gap-2 rounded-xl bg-white dark:bg-slate-800 px-5 py-3 border border-slate-200 dark:border-slate-700 font-medium shadow-sm">Поделиться ссылкой</button>
             </div>
           </div>
-          <div class="rounded-3xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-soft space-y-4">
-            <div>
-              <h3 class="text-lg font-semibold">Организационная информация</h3>
-              <ul class="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc pl-5">
-                <li>Площадка: технопарк РГСУ, Москва, ул. Беговая, д. 12.</li>
-                <li>Документ об обучении: удостоверение о повышении квалификации установленного образца.</li>
-                <li>Необходимые навыки: базовый уровень владения CAD, уверенный ПК.</li>
-                <li>Рекомендуемая одежда: закрытая обувь, удобная форма для работы в мастерских.</li>
-              </ul>
+          <div class="rounded-3xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-soft">
+            <h3 class="font-semibold mb-2">Адреса</h3>
+            <div class="grid sm:grid-cols-2 gap-4 text-sm text-slate-700 dark:text-slate-300">
+              <div><div class="font-medium">ВДНХ</div><div>ул. Вильгельма Пика, 4, корп. 8</div></div>
+              <div><div class="font-medium">Беговая</div><div>ул. Беговая, 12</div></div>
             </div>
-            <div>
-              <h3 class="text-lg font-semibold">Связанные программы</h3>
-              <ul class="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc pl-5">
-                <li><a class="hover:underline" href="index.html#courses">Промышленный дизайн и инжиниринг (72 ч)</a></li>
-                <li><a class="hover:underline" href="index.html#courses">Инженерный дизайн (САПР)</a></li>
-              </ul>
+            <div class="mt-6">
+              <div class="flex items-center gap-2 mb-3">
+                <button class="px-3 py-1.5 rounded-xl text-sm border bg-slate-900 text-white dark:bg-white dark:text-slate-900 border-slate-900 dark:border-white" data-maptab="0">ВДНХ</button>
+                <button class="px-3 py-1.5 rounded-xl text-sm border bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700" data-maptab="1">Беговая</button>
+              </div>
+              <div class="relative w-full overflow-hidden rounded-2xl border border-slate-200 dark:border-slate-700 aspect-video">
+                <iframe title="Карта — ВДНХ" class="absolute inset-0 w-full h-full" data-map="0" src="https://www.google.com/maps?q=%D0%9C%D0%BE%D1%81%D0%BA%D0%B2%D0%B0,%20%D1%83%D0%BB.%20%D0%92%D0%B8%D0%BB%D1%8C%D0%B3%D0%B5%D0%BB%D1%8C%D0%BC%D0%B0%20%D0%9F%D0%B8%D0%BA%D0%B0,%204,%20%D0%BA%D0%BE%D1%80%D0%BF.%208&output=embed" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+                <iframe title="Карта — Беговая" class="absolute inset-0 w-full h-full opacity-0 pointer-events-none" data-map="1" src="https://www.google.com/maps?q=%D0%9C%D0%BE%D1%81%D0%BA%D0%B2%D0%B0,%20%D1%83%D0%BB.%20%D0%91%D0%B5%D0%B3%D0%BE%D0%B2%D0%B0%D1%8F,%2012&output=embed" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+              </div>
             </div>
-            <div class="text-sm text-slate-500 dark:text-slate-400">© <span id="y"></span> Step3D.Lab · Технопарк РГСУ</div>
+            <div class="mt-4 text-sm text-slate-500 dark:text-slate-400">© <span id="y"></span> Технопарк РГСУ</div>
           </div>
         </div>
       </div>
-    </section>
+
+      <div class="border-t border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 mt-16">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+          <div class="grid sm:grid-cols-2 md:grid-cols-4 gap-8">
+            <div><div class="text-sm font-semibold mb-3">Продукты</div><ul class="space-y-2 text-sm"><li><a href="index.html#services" class="hover:underline">CAD/CAE‑моделирование</a></li><li><a href="index.html#services" class="hover:underline">Реверсивный инжиниринг</a></li><li><a href="index.html#services" class="hover:underline">Аддитивное производство</a></li><li><a href="index.html#services" class="hover:underline">Прототипирование</a></li></ul></div>
+            <div><div class="text-sm font-semibold mb-3">Образование</div><ul class="space-y-2 text-sm"><li><a href="index.html#courses" class="hover:underline">Курсы ДПО</a></li><li><a href="index.html#courses" class="hover:underline">Проектные школы</a></li><li><a href="index.html#courses" class="hover:underline">Силлабусы</a></li><li><a href="index.html#contacts" class="hover:underline">Заявка на обучение</a></li></ul></div>
+            <div><div class="text-sm font-semibold mb-3">Проекты</div><ul class="space-y-2 text-sm"><li><a href="index.html#projects" class="hover:underline">MedTech</a></li><li><a href="index.html#projects" class="hover:underline">Robotics</a></li><li><a href="index.html#projects" class="hover:underline">Reverse engineering</a></li><li><a href="index.html#projects" class="hover:underline">Design &amp; Render</a></li></ul></div>
+            <div><div class="text-sm font-semibold mb-3">Ресурсы</div><ul class="space-y-2 text-sm"><li><a href="#" class="hover:underline">Методические материалы</a></li><li><a href="#" class="hover:underline">3D‑модели (STP)</a></li><li><a href="#" class="hover:underline">Политика данных</a></li><li><a href="#" class="hover:underline">Блог</a></li></ul></div>
+          </div>
+          <div class="mt-10 flex flex-wrap items-center justify-between gap-4 text-xs text-slate-500 dark:text-slate-400">
+            <div class="flex flex-wrap gap-3"><a href="#" class="hover:underline">Конфиденциальность</a><a href="#" class="hover:underline">Условия использования</a><a href="#" class="hover:underline">Cookies</a><a href="#" class="hover:underline">Контакты</a></div>
+            <div class="flex items-center gap-2"><span aria-hidden>🌐</span><select class="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-2 py-1"><option>Русский (RU)</option><option>English (EN)</option></select></div>
+          </div>
+          <div class="mt-6 text-xs text-slate-500 dark:text-slate-400">© <span id="y2"></span> Step3D.Lab · Все права защищены</div>
+        </div>
+      </div>
+    </footer>
   </main>
 
   <div id="modal" class="fixed inset-0 bg-slate-900/60 backdrop-blur-sm hidden z-50">
@@ -505,8 +520,47 @@
       alert('Заявка отправлена! (демо)')
     })
 
+    const mapTabs = document.querySelectorAll('[data-maptab]')
+    if(mapTabs.length){
+      mapTabs.forEach(btn=> btn.addEventListener('click', ()=>{
+        const i = btn.dataset.maptab
+        mapTabs.forEach(b=>{
+          const active = b===btn
+          b.classList.toggle('bg-slate-900', active)
+          b.classList.toggle('text-white', active)
+          b.classList.toggle('dark:bg-white', active)
+          b.classList.toggle('dark:text-slate-900', active)
+        })
+        document.querySelectorAll('[data-map]').forEach(frame=>{
+          const active = frame.dataset.map === i
+          frame.classList.toggle('opacity-0', !active)
+          frame.classList.toggle('pointer-events-none', !active)
+        })
+      }))
+    }
+
+    document.getElementById('shareLink')?.addEventListener('click', async ()=>{
+      const url = window.location.href
+      const title = document.title
+      if(navigator.share){
+        try {
+          await navigator.share({ title, url })
+        } catch (err) {
+          if(err?.name !== 'AbortError') alert('Не удалось поделиться ссылкой. Попробуйте ещё раз.')
+        }
+        return
+      }
+      try {
+        await navigator.clipboard.writeText(url)
+        alert('Ссылка скопирована в буфер обмена')
+      } catch (err) {
+        prompt('Скопируйте ссылку вручную:', url)
+      }
+    })
+
     const y = new Date().getFullYear()
     document.getElementById('y').textContent = y
+    document.getElementById('y2').textContent = y
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the course page contacts section with the shared site footer from the main page
- add supporting map toggle and share-link scripts plus year update for the duplicated footer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3d7073dc883338518d8260cd87cda