### PR TITLE
feat: redesign schedule section with collapsible details

### DIFF
--- a/reverse-additive.html
+++ b/reverse-additive.html
@@ -156,103 +156,137 @@
       <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
         <h2 class="text-3xl md:text-4xl font-bold mb-6">Календарно-тематический план</h2>
         <p class="text-slate-600 dark:text-slate-300 mb-6 max-w-3xl">Формат очного интенсива на 6 учебных дней (понедельник—суббота) по 8 академических часов. Каждому модулю соответствует практическая работа или мастер-класс с итоговым контролем.</p>
-        <div class="overflow-x-auto rounded-3xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900/40">
-          <table class="min-w-full divide-y divide-slate-200 dark:divide-slate-700 text-sm">
-            <thead class="bg-slate-100 dark:bg-slate-800/60 text-slate-600 dark:text-slate-300 uppercase tracking-wide text-xs">
-              <tr>
-                <th class="px-4 py-3 text-left font-medium">День</th>
-                <th class="px-4 py-3 text-left font-medium">Модуль / дисциплина</th>
-                <th class="px-4 py-3 text-left font-medium">Всего часов</th>
-                <th class="px-4 py-3 text-left font-medium">Лекции</th>
-                <th class="px-4 py-3 text-left font-medium">Практика</th>
-                <th class="px-4 py-3 text-left font-medium">Контроль</th>
-                <th class="px-4 py-3 text-left font-medium">Форма контроля</th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-slate-200 dark:divide-slate-800 text-slate-700 dark:text-slate-200">
-              <tr>
-                <td class="px-4 py-3 align-top font-semibold">01 · Пн</td>
-                <td class="px-4 py-3 space-y-2">
-                  <div><strong>Лекция.</strong> Реверсивный инжиниринг и технологии аддитивного производства. Опыт РГСУ и кейсы чемпионатов Hi-Tech. Охрана труда и техника безопасности.</div>
-                  <div><strong>Мастер-класс №1.</strong> CAD/CAM-моделирование мастер-моделей и метаформ для литья полимеров и выплавляемых моделей.</div>
-                  <div><strong>Практика №1.</strong> Выбор средства оцифровки и оснастки. Калибровка 3D-сканера (RangeVision Spectrum).</div>
-                  <div><strong>Практика №2.</strong> 3D-сканирование на стационарном сканере (RangeVision Spectrum).</div>
-                </td>
-                <td class="px-4 py-3">10</td>
-                <td class="px-4 py-3">1</td>
-                <td class="px-4 py-3">8.5</td>
-                <td class="px-4 py-3">0.5</td>
-                <td class="px-4 py-3">Устный опрос, зачёт</td>
-              </tr>
-              <tr class="bg-slate-50/60 dark:bg-slate-800/30">
-                <td class="px-4 py-3 align-top font-semibold">02 · Вт</td>
-                <td class="px-4 py-3 space-y-2">
-                  <div><strong>Практика №3.</strong> Реверсивный инжиниринг в Geomagic Design X (базовые функции).</div>
-                  <div><strong>Мастер-класс №2.</strong> Основы 3D-печати (FDM, оборудование PICASO 3D) от индустриального партнёра.</div>
-                  <div><strong>Практика №4.</strong> Подготовка моделей к 3D-печати по технологиям FDM/DLP/SLA. Запуск печати.</div>
-                </td>
-                <td class="px-4 py-3">8</td>
-                <td class="px-4 py-3">0.5</td>
-                <td class="px-4 py-3">6</td>
-                <td class="px-4 py-3">1.5</td>
-                <td class="px-4 py-3">Зачёт</td>
-              </tr>
-              <tr>
-                <td class="px-4 py-3 align-top font-semibold">03 · Ср</td>
-                <td class="px-4 py-3 space-y-2">
-                  <div><strong>Мастер-класс №3.</strong> 3D-сканирование ручным оптическим сканером (Artec Eva).</div>
-                  <div><strong>Практика №5.</strong> Реверсивный инжиниринг в Geomagic Design X (продвинутые функции).</div>
-                </td>
-                <td class="px-4 py-3">8</td>
-                <td class="px-4 py-3">1.5</td>
-                <td class="px-4 py-3">6</td>
-                <td class="px-4 py-3">0.5</td>
-                <td class="px-4 py-3">Устный опрос, зачёт</td>
-              </tr>
-              <tr class="bg-slate-50/60 dark:bg-slate-800/30">
-                <td class="px-4 py-3 align-top font-semibold">04 · Чт</td>
-                <td class="px-4 py-3 space-y-2">
-                  <div><strong>Мастер-класс №4.</strong> Основы 3D-печати по технологиям DLP/SLA (индустриальный партнёр).</div>
-                  <div><strong>Практика №6.</strong> Подготовка моделей к печати (FDM/DLP/SLA). Запуск печати.</div>
-                  <div><strong>Свободный практикум.</strong> Отработка навыков 3D-сканирования, реверсивного инжиниринга и 3D-печати.</div>
-                </td>
-                <td class="px-4 py-3">8</td>
-                <td class="px-4 py-3">1</td>
-                <td class="px-4 py-3">6.5</td>
-                <td class="px-4 py-3">0.5</td>
-                <td class="px-4 py-3">Устный опрос, зачёт</td>
-              </tr>
-              <tr>
-                <td class="px-4 py-3 align-top font-semibold">05 · Пт</td>
-                <td class="px-4 py-3 space-y-2">
-                  <div><strong>Чемпионатное задание.</strong> Выполнение задания формата International High-Tech Competition 2023 по компетенции «Реверсивный инжиниринг».</div>
-                </td>
-                <td class="px-4 py-3">16</td>
-                <td class="px-4 py-3">2</td>
-                <td class="px-4 py-3">12</td>
-                <td class="px-4 py-3">2</td>
-                <td class="px-4 py-3">Экзамен (демонстрационный)</td>
-              </tr>
-              <tr class="bg-slate-50/60 dark:bg-slate-800/30">
-                <td class="px-4 py-3 font-semibold">06 · Сб</td>
-                <td class="px-4 py-3">Резервный день и консультации по индивидуальным проектам.</td>
-                <td class="px-4 py-3">—</td>
-                <td class="px-4 py-3">—</td>
-                <td class="px-4 py-3">—</td>
-                <td class="px-4 py-3">—</td>
-                <td class="px-4 py-3">—</td>
-              </tr>
-              <tr>
-                <td class="px-4 py-3 font-semibold">Итого</td>
-                <td class="px-4 py-3">6 модулей, 4 мастер-класса, 6 практических работ, экзамен</td>
-                <td class="px-4 py-3">48 ч</td>
-                <td class="px-4 py-3">6</td>
-                <td class="px-4 py-3">32</td>
-                <td class="px-4 py-3">10</td>
-                <td class="px-4 py-3">Итоговый зачёт</td>
-              </tr>
-            </tbody>
-          </table>
+        <div class="space-y-4">
+          <details class="group rounded-3xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+            <summary class="flex cursor-pointer flex-col gap-3 rounded-3xl px-5 py-4 transition-colors group-open:bg-slate-50/80 dark:group-open:bg-slate-800/40 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <span class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">01 · Понедельник</span>
+                <h3 class="text-lg font-semibold">Старт, техника безопасности и введение в реверсивный инжиниринг</h3>
+              </div>
+              <div class="flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
+                <span class="rounded-full bg-slate-100 px-3 py-1 dark:bg-slate-800">10 ч</span>
+                <span class="rounded-full bg-emerald-100 px-3 py-1 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200">Лекции 1 ч</span>
+                <span class="rounded-full bg-sky-100 px-3 py-1 text-sky-700 dark:bg-sky-500/20 dark:text-sky-200">Практика 8,5 ч</span>
+                <span class="rounded-full bg-amber-100 px-3 py-1 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200">Контроль 0,5 ч</span>
+              </div>
+            </summary>
+            <div class="border-t border-slate-100 px-5 py-5 text-sm leading-relaxed dark:border-slate-800">
+              <ul class="space-y-3">
+                <li><strong>Лекция.</strong> Реверсивный инжиниринг и технологии аддитивного производства. Опыт РГСУ и кейсы чемпионатов Hi-Tech. Охрана труда и техника безопасности.</li>
+                <li><strong>Мастер-класс №1.</strong> CAD/CAM-моделирование мастер-моделей и метаформ для литья полимеров и выплавляемых моделей.</li>
+                <li><strong>Практика №1.</strong> Выбор средства оцифровки и оснастки. Калибровка 3D-сканера (RangeVision Spectrum).</li>
+                <li><strong>Практика №2.</strong> 3D-сканирование на стационарном сканере (RangeVision Spectrum).</li>
+                <li class="text-slate-500 dark:text-slate-400">Форма контроля: устный опрос, зачёт.</li>
+              </ul>
+            </div>
+          </details>
+          <details class="group rounded-3xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+            <summary class="flex cursor-pointer flex-col gap-3 rounded-3xl px-5 py-4 transition-colors group-open:bg-slate-50/80 dark:group-open:bg-slate-800/40 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <span class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">02 · Вторник</span>
+                <h3 class="text-lg font-semibold">Практика в Geomagic и основы 3D-печати</h3>
+              </div>
+              <div class="flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
+                <span class="rounded-full bg-slate-100 px-3 py-1 dark:bg-slate-800">8 ч</span>
+                <span class="rounded-full bg-emerald-100 px-3 py-1 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200">Лекции 0,5 ч</span>
+                <span class="rounded-full bg-sky-100 px-3 py-1 text-sky-700 dark:bg-sky-500/20 dark:text-sky-200">Практика 6 ч</span>
+                <span class="rounded-full bg-amber-100 px-3 py-1 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200">Контроль 1,5 ч</span>
+              </div>
+            </summary>
+            <div class="border-t border-slate-100 px-5 py-5 text-sm leading-relaxed dark:border-slate-800">
+              <ul class="space-y-3">
+                <li><strong>Практика №3.</strong> Реверсивный инжиниринг в Geomagic Design X (базовые функции).</li>
+                <li><strong>Мастер-класс №2.</strong> Основы 3D-печати (FDM, оборудование PICASO 3D) от индустриального партнёра.</li>
+                <li><strong>Практика №4.</strong> Подготовка моделей к 3D-печати по технологиям FDM/DLP/SLA. Запуск печати.</li>
+                <li class="text-slate-500 dark:text-slate-400">Форма контроля: зачёт.</li>
+              </ul>
+            </div>
+          </details>
+          <details class="group rounded-3xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+            <summary class="flex cursor-pointer flex-col gap-3 rounded-3xl px-5 py-4 transition-colors group-open:bg-slate-50/80 dark:group-open:bg-slate-800/40 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <span class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">03 · Среда</span>
+                <h3 class="text-lg font-semibold">Ручное 3D-сканирование и продвинутые инструменты</h3>
+              </div>
+              <div class="flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
+                <span class="rounded-full bg-slate-100 px-3 py-1 dark:bg-slate-800">8 ч</span>
+                <span class="rounded-full bg-emerald-100 px-3 py-1 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200">Лекции 1,5 ч</span>
+                <span class="rounded-full bg-sky-100 px-3 py-1 text-sky-700 dark:bg-sky-500/20 dark:text-sky-200">Практика 6 ч</span>
+                <span class="rounded-full bg-amber-100 px-3 py-1 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200">Контроль 0,5 ч</span>
+              </div>
+            </summary>
+            <div class="border-t border-slate-100 px-5 py-5 text-sm leading-relaxed dark:border-slate-800">
+              <ul class="space-y-3">
+                <li><strong>Мастер-класс №3.</strong> 3D-сканирование ручным оптическим сканером (Artec Eva).</li>
+                <li><strong>Практика №5.</strong> Реверсивный инжиниринг в Geomagic Design X (продвинутые функции).</li>
+                <li class="text-slate-500 dark:text-slate-400">Форма контроля: устный опрос, зачёт.</li>
+              </ul>
+            </div>
+          </details>
+          <details class="group rounded-3xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+            <summary class="flex cursor-pointer flex-col gap-3 rounded-3xl px-5 py-4 transition-colors group-open:bg-slate-50/80 dark:group-open:bg-slate-800/40 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <span class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">04 · Четверг</span>
+                <h3 class="text-lg font-semibold">Продвинутые технологии печати и свободный практикум</h3>
+              </div>
+              <div class="flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
+                <span class="rounded-full bg-slate-100 px-3 py-1 dark:bg-slate-800">8 ч</span>
+                <span class="rounded-full bg-emerald-100 px-3 py-1 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200">Лекции 1 ч</span>
+                <span class="rounded-full bg-sky-100 px-3 py-1 text-sky-700 dark:bg-sky-500/20 dark:text-sky-200">Практика 6,5 ч</span>
+                <span class="rounded-full bg-amber-100 px-3 py-1 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200">Контроль 0,5 ч</span>
+              </div>
+            </summary>
+            <div class="border-t border-slate-100 px-5 py-5 text-sm leading-relaxed dark:border-slate-800">
+              <ul class="space-y-3">
+                <li><strong>Мастер-класс №4.</strong> Основы 3D-печати по технологиям DLP/SLA (индустриальный партнёр).</li>
+                <li><strong>Практика №6.</strong> Подготовка моделей к печати (FDM/DLP/SLA). Запуск печати.</li>
+                <li><strong>Свободный практикум.</strong> Отработка навыков 3D-сканирования, реверсивного инжиниринга и 3D-печати.</li>
+                <li class="text-slate-500 dark:text-slate-400">Форма контроля: устный опрос, зачёт.</li>
+              </ul>
+            </div>
+          </details>
+          <details class="group rounded-3xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+            <summary class="flex cursor-pointer flex-col gap-3 rounded-3xl px-5 py-4 transition-colors group-open:bg-slate-50/80 dark:group-open:bg-slate-800/40 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <span class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">05 · Пятница</span>
+                <h3 class="text-lg font-semibold">Чемпионатный день и демонстрационный экзамен</h3>
+              </div>
+              <div class="flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
+                <span class="rounded-full bg-slate-100 px-3 py-1 dark:bg-slate-800">16 ч</span>
+                <span class="rounded-full bg-emerald-100 px-3 py-1 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200">Лекции 2 ч</span>
+                <span class="rounded-full bg-sky-100 px-3 py-1 text-sky-700 dark:bg-sky-500/20 dark:text-sky-200">Практика 12 ч</span>
+                <span class="rounded-full bg-amber-100 px-3 py-1 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200">Контроль 2 ч</span>
+              </div>
+            </summary>
+            <div class="border-t border-slate-100 px-5 py-5 text-sm leading-relaxed dark:border-slate-800">
+              <ul class="space-y-3">
+                <li><strong>Чемпионатное задание.</strong> Выполнение задания формата International High-Tech Competition 2023 по компетенции «Реверсивный инжиниринг».</li>
+                <li class="text-slate-500 dark:text-slate-400">Форма контроля: демонстрационный экзамен.</li>
+              </ul>
+            </div>
+          </details>
+          <details class="group rounded-3xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/40">
+            <summary class="flex cursor-pointer flex-col gap-3 rounded-3xl px-5 py-4 transition-colors group-open:bg-slate-50/80 dark:group-open:bg-slate-800/40 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <span class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">06 · Суббота</span>
+                <h3 class="text-lg font-semibold">Резервный день и консультации</h3>
+              </div>
+              <div class="flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
+                <span class="rounded-full bg-slate-100 px-3 py-1 dark:bg-slate-800">—</span>
+                <span class="rounded-full bg-emerald-100 px-3 py-1 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200">Лекции —</span>
+                <span class="rounded-full bg-sky-100 px-3 py-1 text-sky-700 dark:bg-sky-500/20 dark:text-sky-200">Практика —</span>
+                <span class="rounded-full bg-amber-100 px-3 py-1 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200">Контроль —</span>
+              </div>
+            </summary>
+            <div class="border-t border-slate-100 px-5 py-5 text-sm leading-relaxed dark:border-slate-800">
+              <p>Резервный день и консультации по индивидуальным проектам.</p>
+            </div>
+          </details>
+          <div class="rounded-3xl border border-dashed border-slate-300 bg-white/60 p-6 text-sm leading-relaxed shadow-sm dark:border-slate-700 dark:bg-slate-900/20">
+            <h3 class="text-base font-semibold">Итог по программе</h3>
+            <p class="mt-2 text-slate-600 dark:text-slate-300">6 модулей, 4 мастер-класса, 6 практических работ и демонстрационный экзамен. Общий объём — <strong>48 академических часов</strong>, из них 6 часов лекций, 32 часа практики и 10 часов контроля.</p>
+            <p class="mt-3 text-slate-500 dark:text-slate-400">Форма итогового контроля — зачёт.</p>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- replace the static table for the calendar schedule with a vertical accordion
- highlight hours breakdown for each day with badges and keep control information
- add a final summary card describing totals for the programme

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3dcdbf4f8833382d48f1b80dcbb4b