### PR TITLE
Add contact references for services and education

### DIFF
--- a/index.html
+++ b/index.html
@@ -576,6 +576,23 @@
             <button class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-5 py-3 text-white font-medium shadow hover:bg-slate-800 focus:outline-none focus:ring-4 focus:ring-slate-300" id="openModal2">Оставить заявку</button>
             <a href="https://t.me/step_3d_mngr" target="_blank" rel="noreferrer" class="inline-flex items-center gap-2 rounded-xl bg-white dark:bg-slate-800 px-5 py-3 border border-slate-200 dark:border-slate-700 font-medium shadow-sm hover:shadow focus:outline-none focus:ring-4 focus:ring-slate-200 dark:focus:ring-slate-700">Написать нам в телеграм</a>
           </div>
+          <div class="mt-8 grid gap-4 text-sm text-slate-700 dark:text-slate-300">
+            <div class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+              <div class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">CRTD услуги</div>
+              <div class="mt-2 inline-flex items-center gap-2 rounded-xl bg-slate-100 px-3 py-1.5 font-mono text-base text-slate-900 dark:bg-slate-700/70 dark:text-slate-100">projectstep3d</div>
+              <div class="mt-1 text-xs text-slate-500 dark:text-slate-400">Почта для запросов по проектам и услугам CRTD.</div>
+            </div>
+            <div class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+              <div class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Toro3D услуги</div>
+              <div class="mt-2 inline-flex items-center gap-2 rounded-xl bg-slate-100 px-3 py-1.5 font-mono text-base text-slate-900 dark:bg-slate-700/70 dark:text-slate-100">nikita-manager-step3d-telegram</div>
+              <div class="mt-1 text-xs text-slate-500 dark:text-slate-400">Контакт в Telegram для оперативной связи по Toro3D.</div>
+            </div>
+            <div class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+              <div class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Образовательные вопросы</div>
+              <div class="mt-2 inline-flex items-center gap-2 rounded-xl bg-slate-100 px-3 py-1.5 font-mono text-base text-slate-900 dark:bg-slate-700/70 dark:text-slate-100">technopark.rdsu</div>
+              <div class="mt-1 text-xs text-slate-500 dark:text-slate-400">Почта для курсов ДПО и любых образовательных запросов.</div>
+            </div>
+          </div>
         </div>
         <div class="rounded-3xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-soft">
           <h3 class="font-semibold mb-2">Адреса</h3>

--- a/reverse-additive.html
+++ b/reverse-additive.html
@@ -366,6 +366,23 @@
               <a href="https://t.me/step_3d_mngr" target="_blank" rel="noreferrer" class="inline-flex items-center gap-2 rounded-xl bg-white dark:bg-slate-800 px-5 py-3 border border-slate-200 dark:border-slate-700 font-medium shadow-sm hover:shadow focus:outline-none focus:ring-4 focus:ring-slate-200 dark:focus:ring-slate-700">Написать нам в телеграм</a>
               <button id="shareLink" class="inline-flex items-center gap-2 rounded-xl bg-white dark:bg-slate-800 px-5 py-3 border border-slate-200 dark:border-slate-700 font-medium shadow-sm">Поделиться ссылкой</button>
             </div>
+            <div class="mt-8 grid gap-4 text-sm text-slate-700 dark:text-slate-300">
+              <div class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+                <div class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">CRTD услуги</div>
+                <div class="mt-2 inline-flex items-center gap-2 rounded-xl bg-slate-100 px-3 py-1.5 font-mono text-base text-slate-900 dark:bg-slate-700/70 dark:text-slate-100">projectstep3d</div>
+                <div class="mt-1 text-xs text-slate-500 dark:text-slate-400">Почта для запросов по проектам и услугам CRTD.</div>
+              </div>
+              <div class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+                <div class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Toro3D услуги</div>
+                <div class="mt-2 inline-flex items-center gap-2 rounded-xl bg-slate-100 px-3 py-1.5 font-mono text-base text-slate-900 dark:bg-slate-700/70 dark:text-slate-100">nikita-manager-step3d-telegram</div>
+                <div class="mt-1 text-xs text-slate-500 dark:text-slate-400">Контакт в Telegram для оперативной связи по Toro3D.</div>
+              </div>
+              <div class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+                <div class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Образовательные вопросы</div>
+                <div class="mt-2 inline-flex items-center gap-2 rounded-xl bg-slate-100 px-3 py-1.5 font-mono text-base text-slate-900 dark:bg-slate-700/70 dark:text-slate-100">technopark.rdsu</div>
+                <div class="mt-1 text-xs text-slate-500 dark:text-slate-400">Почта для курсов ДПО и любых образовательных запросов.</div>
+              </div>
+            </div>
           </div>
           <div class="rounded-3xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-soft">
             <h3 class="font-semibold mb-2">Адреса</h3>


### PR DESCRIPTION
## Summary
- add dedicated contact cards in the main site footer for CRTD, Toro3D, and educational inquiries
- mirror the same contact details on the reverse-additive landing page so both sections share the updated information

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d3dd67e7c883339c368a19f3c8e7da