### PR TITLE
Add logo image to navigation branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
       <nav class="mb-10" aria-label="Главная навигация">
         <div class="flex items-center justify-between gap-6">
           <a href="#top" class="flex items-center gap-3 font-semibold">
-            <svg viewBox="0 0 64 64" class="h-8 w-8"><defs><linearGradient id="g3d" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0ea5e9"/><stop offset="1" stop-color="#22c55e"/></linearGradient></defs><rect x="6" y="6" width="52" height="52" rx="12" fill="url(#g3d)"/><path d="M20 44V20l12-6 12 6v24l-12 6-12-6z M32 14v36" stroke="#fff" stroke-width="2" fill="none"/></svg>
+            <img src="Logo_Step_3D.jpg" alt="Логотип Step3D.Lab" class="h-10 w-10 rounded-xl object-cover" />
             Step3D.Lab
           </a>
           <div class="hidden md:flex items-center gap-1" id="links">

--- a/reverse-additive.html
+++ b/reverse-additive.html
@@ -31,11 +31,7 @@
       <nav class="mb-12" aria-label="Навигация по странице">
         <div class="flex items-center justify-between gap-6">
           <a href="index.html" class="flex items-center gap-3 font-semibold">
-            <svg viewBox="0 0 64 64" class="h-8 w-8" aria-hidden>
-              <defs><linearGradient id="logo" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0ea5e9"/><stop offset="1" stop-color="#22c55e"/></linearGradient></defs>
-              <rect x="6" y="6" width="52" height="52" rx="12" fill="url(#logo)"/>
-              <path d="M20 44V20l12-6 12 6v24l-12 6-12-6z M32 14v36" stroke="#fff" stroke-width="2" fill="none"/>
-            </svg>
+            <img src="Logo_Step_3D.jpg" alt="Логотип Step3D.Lab" class="h-10 w-10 rounded-xl object-cover" />
             Step3D.Lab
           </a>
           <div class="hidden md:flex items-center gap-1" id="links"></div>


### PR DESCRIPTION
## Summary
- replace the SVG placeholder icon in the header brand area with the actual Step3D.Lab logo image on both pages

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d3e427734c8333a30762c3f0b2fbd0