### PR TITLE
Remove Telegram link from contact buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -509,7 +509,6 @@
           <p class="mt-3 text-slate-600 dark:text-slate-300 max-w-prose">Задайте вопрос или оставьте заявку — поможем выбрать формат: учебный модуль, проект, НИОКР или услуга.</p>
           <div class="mt-6 flex flex-wrap gap-3">
             <button class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-5 py-3 text-white font-medium shadow hover:bg-slate-800 focus:outline-none focus:ring-4 focus:ring-slate-300" id="openModal2">Оставить заявку</button>
-            <a href="https://t.me/step_3d_mngr" target="_blank" rel="noreferrer" class="inline-flex items-center gap-2 rounded-xl bg-white dark:bg-slate-800 px-5 py-3 border border-slate-200 dark:border-slate-700 font-medium shadow-sm hover:shadow focus:outline-none focus:ring-4 focus:ring-slate-200 dark:focus:ring-slate-700">Написать нам в телеграм</a>
           </div>
           <div class="mt-8 grid gap-4 text-sm text-slate-700 dark:text-slate-300 sm:grid-cols-2">
             <div class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800">

--- a/reverse-additive.html
+++ b/reverse-additive.html
@@ -427,7 +427,6 @@
             <p class="mt-3 text-slate-600 dark:text-slate-300 max-w-prose">Задайте вопрос или оставьте заявку — поможем выбрать формат: учебный модуль, проект, НИОКР или услугу.</p>
             <div class="mt-6 flex flex-wrap gap-3">
               <button class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-5 py-3 text-white font-medium shadow hover:bg-slate-800 focus:outline-none focus:ring-4 focus:ring-slate-300" id="openModal2">Оставить заявку</button>
-              <a href="https://t.me/step_3d_mngr" target="_blank" rel="noreferrer" class="inline-flex items-center gap-2 rounded-xl bg-white dark:bg-slate-800 px-5 py-3 border border-slate-200 dark:border-slate-700 font-medium shadow-sm hover:shadow focus:outline-none focus:ring-4 focus:ring-slate-200 dark:focus:ring-slate-700">Написать нам в телеграм</a>
               <button id="shareLink" class="inline-flex items-center gap-2 rounded-xl bg-white dark:bg-slate-800 px-5 py-3 border border-slate-200 dark:border-slate-700 font-medium shadow-sm">Поделиться ссылкой</button>
             </div>
             <div class="mt-8 grid gap-4 text-sm text-slate-700 dark:text-slate-300 sm:grid-cols-2">


### PR DESCRIPTION
## Summary
- remove the Telegram contact link that appeared alongside the “Оставить заявку” button on the main page
- do the same cleanup for the reverse-additive landing page, leaving only the request and share actions

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d3e8aa6cd083339d2801a9f167b78a