### PR TITLE
Add blog section with news highlights

### DIFF
--- a/assets/images/index/blog/additive-production.svg
+++ b/assets/images/index/blog/additive-production.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400">
+  <defs>
+    <linearGradient id="grad2" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f97316" />
+      <stop offset="100%" stop-color="#facc15" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="400" rx="32" fill="url(#grad2)" />
+  <g fill="none" stroke="#1f2937" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" opacity="0.9">
+    <path d="M140 120h320v40H140z" />
+    <path d="M200 160v140h200V160" />
+    <path d="M240 220h120" />
+    <path d="M240 260h120" />
+    <path d="M240 300h120" />
+    <circle cx="180" cy="220" r="18" fill="#1f2937" />
+    <circle cx="420" cy="220" r="18" fill="#1f2937" />
+  </g>
+</svg>

--- a/assets/images/index/blog/education-lab.svg
+++ b/assets/images/index/blog/education-lab.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400">
+  <defs>
+    <linearGradient id="grad3" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#22c55e" />
+      <stop offset="100%" stop-color="#14b8a6" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="400" rx="32" fill="url(#grad3)" />
+  <g fill="none" stroke="#f8fafc" stroke-width="10" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M120 160h360l-180-80z" fill="#0f172a" opacity="0.25" />
+    <path d="M150 200h300v120H150z" />
+    <path d="M200 200v120" />
+    <path d="M400 200v120" />
+    <path d="M240 240h120" />
+    <path d="M240 280h120" />
+    <circle cx="300" cy="140" r="18" />
+  </g>
+</svg>

--- a/assets/images/index/blog/reverse-engineering.svg
+++ b/assets/images/index/blog/reverse-engineering.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0ea5e9" />
+      <stop offset="100%" stop-color="#6366f1" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="400" rx="32" fill="url(#grad)" />
+  <g fill="none" stroke="#fff" stroke-width="10" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M120 260l110-160 90 120 60-80 100 140" />
+    <circle cx="230" cy="100" r="26" />
+    <rect x="360" y="220" width="120" height="80" rx="16" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1139,6 +1139,170 @@
       </div>
     </section>
 
+    <!-- Новости и статьи -->
+    <section
+      id="blog"
+      class="py-16 md:py-24 bg-gradient-to-b from-white via-slate-50 to-white dark:from-slate-900 dark:via-slate-900/70 dark:to-slate-900"
+    >
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-6 mb-10">
+          <div>
+            <h2 class="text-3xl md:text-4xl font-bold">Новости и статьи</h2>
+            <p class="mt-3 text-slate-600 dark:text-slate-300 max-w-2xl">
+              Коротко делимся проектами лаборатории, методическими материалами и
+              вдохновляющими кейсами индустриального дизайна и инженерии.
+            </p>
+          </div>
+          <a
+            href="https://t.me/step_3d_mngr"
+            target="_blank"
+            rel="noreferrer"
+            class="inline-flex items-center gap-2 self-start rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-900 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+          >
+            Все обновления в телеграме
+            <svg viewBox="0 0 24 24" class="h-4 w-4">
+              <path
+                d="M5 12h13M13 5l7 7-7 7"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </a>
+        </div>
+
+        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          <article
+            class="group relative overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg dark:border-slate-700 dark:bg-slate-800"
+          >
+            <div class="aspect-[16/10] overflow-hidden">
+              <img
+                src="assets/images/index/blog/reverse-engineering.svg"
+                alt="Реверс-инжиниринг в Step3D.Lab"
+                class="h-full w-full object-cover transition duration-700 group-hover:scale-105"
+                loading="lazy"
+              />
+            </div>
+            <div class="p-6">
+              <div class="flex items-center gap-3 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                <span class="inline-flex items-center rounded-md bg-slate-100 px-2 py-0.5 dark:bg-slate-700">Проекты</span>
+                <time datetime="2024-04-18">18 апреля 2024</time>
+              </div>
+              <h3 class="mt-4 text-xl font-semibold text-slate-900 dark:text-white">
+                Как мы за 5 дней восстановили 3D‑модель редкой детали
+              </h3>
+              <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">
+                Сканирование, облака точек, подготовка поверхности и печать на
+                SLS — рассказываем про рабочий процесс лаборатории шаг за шагом.
+              </p>
+              <a
+                href="#"
+                class="mt-5 inline-flex items-center gap-2 text-sm font-medium text-sky-600 transition hover:text-sky-500 dark:text-sky-300 dark:hover:text-sky-200"
+              >
+                Читать заметку
+                <svg viewBox="0 0 24 24" class="h-4 w-4">
+                  <path
+                    d="M5 12h13M13 5l7 7-7 7"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </a>
+            </div>
+          </article>
+
+          <article
+            class="group relative overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg dark:border-slate-700 dark:bg-slate-800"
+          >
+            <div class="aspect-[16/10] overflow-hidden">
+              <img
+                src="assets/images/index/blog/additive-production.svg"
+                alt="Аддитивное производство"
+                class="h-full w-full object-cover transition duration-700 group-hover:scale-105"
+                loading="lazy"
+              />
+            </div>
+            <div class="p-6">
+              <div class="flex items-center gap-3 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                <span class="inline-flex items-center rounded-md bg-slate-100 px-2 py-0.5 dark:bg-slate-700">Методика</span>
+                <time datetime="2024-03-27">27 марта 2024</time>
+              </div>
+              <h3 class="mt-4 text-xl font-semibold text-slate-900 dark:text-white">
+                7 советов по выбору технологии 3D‑печати под задачу
+              </h3>
+              <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">
+                Как понимать ограничения материалов, точность и экономику разных
+                процессов — чек‑лист для конструкторов и менеджеров проекта.
+              </p>
+              <a
+                href="#"
+                class="mt-5 inline-flex items-center gap-2 text-sm font-medium text-sky-600 transition hover:text-sky-500 dark:text-sky-300 dark:hover:text-sky-200"
+              >
+                Читать статью
+                <svg viewBox="0 0 24 24" class="h-4 w-4">
+                  <path
+                    d="M5 12h13M13 5l7 7-7 7"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </a>
+            </div>
+          </article>
+
+          <article
+            class="group relative overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg dark:border-slate-700 dark:bg-slate-800"
+          >
+            <div class="aspect-[16/10] overflow-hidden">
+              <img
+                src="assets/images/index/blog/education-lab.svg"
+                alt="Обучение в лаборатории"
+                class="h-full w-full object-cover transition duration-700 group-hover:scale-105"
+                loading="lazy"
+              />
+            </div>
+            <div class="p-6">
+              <div class="flex items-center gap-3 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                <span class="inline-flex items-center rounded-md bg-slate-100 px-2 py-0.5 dark:bg-slate-700">Обучение</span>
+                <time datetime="2024-02-10">10 февраля 2024</time>
+              </div>
+              <h3 class="mt-4 text-xl font-semibold text-slate-900 dark:text-white">
+                Новый поток курса по комплексному реверсу: что внутри
+              </h3>
+              <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">
+                Содержание модулей, проектные задания и практика на оборудовании
+                технопарка — делимся, что ждёт слушателей.
+              </p>
+              <a
+                href="#"
+                class="mt-5 inline-flex items-center gap-2 text-sm font-medium text-sky-600 transition hover:text-sky-500 dark:text-sky-300 dark:hover:text-sky-200"
+              >
+                Читать обзор
+                <svg viewBox="0 0 24 24" class="h-4 w-4">
+                  <path
+                    d="M5 12h13M13 5l7 7-7 7"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
     <!-- FAQ -->
     <section id="faq" class="py-16 md:py-24 bg-white dark:bg-slate-900">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -1503,7 +1667,7 @@
     <div
       id="nav-data"
       class="hidden"
-      data-nav='[{"id":"top","label":"Главная"},{"id":"equipment","label":"Оборудование"},{"id":"projects","label":"Проекты"},{"id":"courses","label":"Обучение"},{"id":"team","label":"Команда"},{"id":"faq","label":"FAQ"},{"id":"contacts","label":"Контакты"}]'
+      data-nav='[{"id":"top","label":"Главная"},{"id":"equipment","label":"Оборудование"},{"id":"projects","label":"Проекты"},{"id":"courses","label":"Обучение"},{"id":"team","label":"Команда"},{"id":"blog","label":"Новости"},{"id":"faq","label":"FAQ"},{"id":"contacts","label":"Контакты"}]'
     ></div>
 
     <script>


### PR DESCRIPTION
## Summary
- add a "Новости и статьи" section after the team block with featured posts and call to action
- register the new section in the navigation metadata so it appears in the menus
- add illustrative SVG cover images for each highlighted story

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d3ed2756c0833385fd35f7786b2f17