### PR TITLE
Improve logo sizing and text colors for readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
     </script>
   </head>
   <body
-    class="min-h-screen bg-gradient-to-b from-white to-slate-50 text-slate-800 dark:from-slate-900 dark:to-slate-950 dark:text-slate-100"
+    class="min-h-screen bg-gradient-to-b from-white via-slate-50 to-slate-100 text-slate-900 dark:from-slate-900 dark:via-slate-950 dark:to-black dark:text-slate-100"
   >
     <!-- Прогресс-бар прокрутки -->
     <div
@@ -112,11 +112,11 @@
         <!-- Навигация -->
         <nav class="mb-10 relative" aria-label="Главная навигация">
           <div class="flex items-center gap-6">
-            <a href="#top" class="flex items-center gap-3 font-semibold">
+            <a href="#top" class="flex items-center gap-3 font-semibold text-slate-900 dark:text-white">
               <img
                 src="Logo_Step_3D.jpg"
                 alt="Логотип Step3D.Lab"
-                class="h-10 w-10 rounded-xl object-cover"
+                class="h-12 w-12 rounded-2xl object-cover shadow-sm"
               />
               Step3D.Lab
             </a>
@@ -131,8 +131,7 @@
                 href="#contacts"
                 id="contactDesktop"
                 class="inline-flex items-center justify-center rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:-translate-y-0.5 hover:bg-slate-800 focus:outline-none focus:ring-4 focus:ring-slate-300 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200 dark:focus:ring-slate-700"
-                >Связаться с нами</a
-              >
+              >Связаться с нами</a>
             </div>
             <div class="md:hidden flex items-center gap-2 ml-auto">
               <button
@@ -184,7 +183,7 @@
               Лаборатория промдизайна и инжиниринга (R22.Lab)
             </h1>
             <p
-              class="mt-4 text-lg text-slate-600 dark:text-slate-300 max-w-prose"
+              class="mt-4 text-lg text-slate-700 dark:text-slate-200 max-w-prose"
             >
               CAD/CAE, реверсивный инжиниринг, 3D‑сканирование, аддитивное
               производство. Учим и делаем продукты на базе технопарка РГСУ
@@ -209,7 +208,7 @@
               class="mt-6 hidden rounded-3xl border border-slate-200 dark:border-slate-700 bg-white/80 dark:bg-slate-800/80 glass p-6"
             >
               <h3 class="text-xl font-semibold mb-2">О лаборатории</h3>
-              <p class="text-slate-700 dark:text-slate-300">
+              <p class="text-slate-700 dark:text-slate-200">
                 Step3D.Lab — команда инженеров, дизайнеров и преподавателей.
                 Работаем на базе технопарка РГСУ совместно с ООО «СТЕП 3Д»:
                 выполняем R&amp;D‑проекты, проводим курсы ДПО (48–72 ч),
@@ -273,7 +272,7 @@
     <section id="equipment" class="py-16 md:py-24 bg-white dark:bg-slate-900">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <h2 class="text-3xl md:text-4xl font-bold mb-6">Оборудование и ПО</h2>
-        <p class="text-slate-600 dark:text-slate-300 max-w-3xl">
+        <p class="text-slate-700 dark:text-slate-200 max-w-3xl">
           3D‑сканеры RangeVision и Artec; принтеры FDM/DLP (Ultimaker, Picaso
           3D, Formlabs); лазер Trotec, фрезерные Roland; софт Geomagic, GOM
           Inspect, Inventor, Fusion 360.
@@ -659,11 +658,11 @@
             <h3 class="text-lg font-semibold">
               Изготовление ортезов и протезов
             </h3>
-            <p class="mt-1 text-slate-600 dark:text-slate-300 text-sm">
+            <p class="mt-1 text-slate-700 dark:text-slate-200 text-sm">
               Индивидуальные ортезы и протезы: от скана до готового изделия.
             </p>
             <div
-              class="mt-3 flex flex-wrap gap-2 text-sm text-slate-500 dark:text-slate-300"
+              class="mt-3 flex flex-wrap gap-2 text-sm text-slate-600 dark:text-slate-200"
             >
               <span
                 class="inline-flex items-center rounded-lg bg-slate-100 dark:bg-slate-700 px-2.5 py-1"
@@ -745,13 +744,13 @@
             data-index="0"
           >
             <h3 class="text-lg font-semibold">Промдизайн и прототипирование</h3>
-            <p class="mt-1 text-slate-600 dark:text-slate-300 text-sm">
+            <p class="mt-1 text-slate-700 dark:text-slate-200 text-sm">
               Комплексные проекты по промышленному дизайну: быстрые макеты,
               пользовательские испытания, подготовка к малосерийному
               производству.
             </p>
             <div
-              class="mt-3 flex flex-wrap gap-2 text-sm text-slate-500 dark:text-slate-300"
+              class="mt-3 flex flex-wrap gap-2 text-sm text-slate-600 dark:text-slate-200"
             >
               <span
                 class="inline-flex items-center rounded-lg bg-slate-100 dark:bg-slate-700 px-2.5 py-1"
@@ -830,7 +829,7 @@
             <h3 class="text-lg font-semibold">
               Оцифровка объектов культурного наследия
             </h3>
-            <p class="mt-1 text-slate-600 dark:text-slate-300 text-sm">
+            <p class="mt-1 text-slate-700 dark:text-slate-200 text-sm">
               Сканирование и восстановление геометрии, подготовка экспозиционных
               макетов.
             </p>
@@ -899,12 +898,12 @@
             <h3 class="text-lg font-semibold">
               GenAI и XR‑технологии в инженерии
             </h3>
-            <p class="mt-1 text-slate-600 dark:text-slate-300 text-sm">
+            <p class="mt-1 text-slate-700 dark:text-slate-200 text-sm">
               Используем генеративный ИИ и дополненную/виртуальную реальность
               для ускорения проектирования, ревью и обучения инженеров.
             </p>
             <div
-              class="mt-3 flex flex-wrap gap-2 text-sm text-slate-500 dark:text-slate-300"
+              class="mt-3 flex flex-wrap gap-2 text-sm text-slate-600 dark:text-slate-200"
             >
               <span
                 class="inline-flex items-center rounded-lg bg-slate-100 dark:bg-slate-700 px-2.5 py-1"
@@ -986,7 +985,7 @@
         <h2 class="text-3xl md:text-4xl font-bold mb-6">
           Курсы ДПО и проектные школы
         </h2>
-        <p class="text-slate-600 dark:text-slate-300 max-w-3xl">
+        <p class="text-slate-700 dark:text-slate-200 max-w-3xl">
           Учебные планы на 48–72 часа с индивидуальными проектами, подготовка к
           чемпионатам «Профессионалы», WorldSkills, HI‑TECH.
         </p>
@@ -997,7 +996,7 @@
             Образовательные проекты совместно с ФГБОУ ВО РГСУ
           </summary>
           <ul
-            class="mt-3 list-disc pl-5 text-sm text-slate-600 dark:text-slate-300"
+            class="mt-3 list-disc pl-5 text-sm text-slate-700 dark:text-slate-200"
           >
             <li>Знакомство со сканерами, подготовка объекта</li>
             <li>Обработка сеток: чистка, выравнивание, ремешинг</li>
@@ -1042,11 +1041,11 @@
                     Реверсивный инжиниринг и аддитивное производство
                   </h3>
                 </div>
-                <p class="mt-2 text-slate-600 dark:text-slate-300">
+                <p class="mt-2 text-slate-700 dark:text-slate-200">
                   3D‑сканирование, обработка сканов, CAD, 3D‑печать
                 </p>
                 <div
-                  class="mt-3 flex flex-wrap gap-2 text-sm text-slate-500 dark:text-slate-300"
+                  class="mt-3 flex flex-wrap gap-2 text-sm text-slate-600 dark:text-slate-200"
                 >
                   <span
                     class="inline-flex items-center rounded-lg bg-slate-100 dark:bg-slate-700 px-2.5 py-1"
@@ -1089,10 +1088,10 @@
             />
             <div>
               <div class="font-semibold">Владимир Ганьшин</div>
-              <div class="text-sm text-slate-500 dark:text-slate-300">
+              <div class="text-sm text-slate-600 dark:text-slate-200">
                 руководитель лаборатории
               </div>
-              <div class="mt-1 text-sm text-slate-600 dark:text-slate-300">
+              <div class="mt-1 text-sm text-slate-700 dark:text-slate-200">
                 CAD/AM, реверс, методология ДПО
               </div>
             </div>
@@ -1108,10 +1107,10 @@
             />
             <div>
               <div class="font-semibold">Анна Понкратова</div>
-              <div class="text-sm text-slate-500 dark:text-slate-300">
+              <div class="text-sm text-slate-600 dark:text-slate-200">
                 ведущий инженер‑преподаватель
               </div>
-              <div class="mt-1 text-sm text-slate-600 dark:text-slate-300">
+              <div class="mt-1 text-sm text-slate-700 dark:text-slate-200">
                 3D‑сканирование, обработка сеток
               </div>
             </div>
@@ -1127,10 +1126,10 @@
             />
             <div>
               <div class="font-semibold">Алексей Рекут</div>
-              <div class="text-sm text-slate-500 dark:text-slate-300">
+              <div class="text-sm text-slate-600 dark:text-slate-200">
                 инженер‑конструктор
               </div>
-              <div class="mt-1 text-sm text-slate-600 dark:text-slate-300">
+              <div class="mt-1 text-sm text-slate-700 dark:text-slate-200">
                 CAD, ЧПУ, прототипы
               </div>
             </div>
@@ -1150,7 +1149,7 @@
             <summary class="cursor-pointer font-medium">
               Какие материалы печати доступны?
             </summary>
-            <p class="mt-2 text-slate-600 dark:text-slate-300">
+            <p class="mt-2 text-slate-700 dark:text-slate-200">
               PLA, PETG, ABS, нейлон; смолы DLP/SLA (стандартные и инженерные).
               Постобработка и окраска — доступны.
             </p>
@@ -1161,7 +1160,7 @@
             <summary class="cursor-pointer font-medium">
               Сколько занимает цикл «скан‑CAD‑печать»?
             </summary>
-            <p class="mt-2 text-slate-600 dark:text-slate-300">
+            <p class="mt-2 text-slate-700 dark:text-slate-200">
               От 2 до 10 рабочих дней — зависит от размера, точности и загрузки.
             </p>
           </details>
@@ -1171,7 +1170,7 @@
             <summary class="cursor-pointer font-medium">
               Можно ли обучаться дистанционно?
             </summary>
-            <p class="mt-2 text-slate-600 dark:text-slate-300">
+            <p class="mt-2 text-slate-700 dark:text-slate-200">
               Да: теория и разбор кейсов — онлайн. Практика и сканирование —
               очно.
             </p>
@@ -1182,7 +1181,7 @@
             <summary class="cursor-pointer font-medium">
               Выдаёте ли документы о повышении квалификации?
             </summary>
-            <p class="mt-2 text-slate-600 dark:text-slate-300">
+            <p class="mt-2 text-slate-700 dark:text-slate-200">
               Да, по итогам программ ДПО (48–72 ч) — удостоверение
               установленного образца.
             </p>
@@ -1193,7 +1192,7 @@
             <summary class="cursor-pointer font-medium">
               Берёте проекты под НИР/НИОКР?
             </summary>
-            <p class="mt-2 text-slate-600 dark:text-slate-300">
+            <p class="mt-2 text-slate-700 dark:text-slate-200">
               Да, оформляем задачи как исследовательские проекты: публикации,
               отчёты.
             </p>
@@ -1204,7 +1203,7 @@
             <summary class="cursor-pointer font-medium">
               Как оставить заявку?
             </summary>
-            <p class="mt-2 text-slate-600 dark:text-slate-300">
+            <p class="mt-2 text-slate-700 dark:text-slate-200">
               Нажмите «Оставить заявку» и заполните форму — мы свяжемся.
             </p>
           </details>
@@ -1221,7 +1220,7 @@
         <div class="grid md:grid-cols-2 gap-10 items-center">
           <div>
             <h2 class="text-3xl md:text-4xl font-bold">Контакты</h2>
-            <p class="mt-3 text-slate-600 dark:text-slate-300 max-w-prose">
+            <p class="mt-3 text-slate-700 dark:text-slate-200 max-w-prose">
               Задайте вопрос или оставьте заявку — поможем выбрать формат:
               учебный модуль, проект, НИОКР или услуга.
             </p>
@@ -1241,7 +1240,7 @@
               >
             </div>
             <div
-              class="mt-8 grid gap-4 text-sm text-slate-700 dark:text-slate-300 sm:grid-cols-2"
+              class="mt-8 grid gap-4 text-sm text-slate-700 dark:text-slate-200 sm:grid-cols-2"
             >
               <div
                 class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800"
@@ -1328,7 +1327,7 @@
           >
             <h3 class="font-semibold mb-2">Адреса</h3>
             <div
-              class="grid sm:grid-cols-2 gap-4 text-sm text-slate-700 dark:text-slate-300"
+              class="grid sm:grid-cols-2 gap-4 text-sm text-slate-700 dark:text-slate-200"
             >
               <div>
                 <div class="font-medium">ВДНХ</div>
@@ -1420,7 +1419,7 @@
         class="relative w-full max-w-lg rounded-2xl bg-white dark:bg-slate-900 p-6 shadow-2xl border border-slate-200 dark:border-slate-700"
       >
         <h3 class="text-xl font-semibold">Оставить заявку</h3>
-        <p class="text-slate-600 dark:text-slate-300 mt-1">
+        <p class="text-slate-700 dark:text-slate-200 mt-1">
           Заполните контакты — мы свяжемся и обсудим задачу.
         </p>
         <form id="requestForm" class="mt-4 grid gap-3">


### PR DESCRIPTION
## Summary
- enlarge the Step3D.Lab logo in the header and ensure navigation text has higher contrast for better recognition
- refresh the page background gradient and elevate default text color tokens for improved legibility across sections
- adjust service, contact, and FAQ copy to use darker slate tones in light mode and lighter tones in dark mode

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3ecdf74b483339b1fa8c42c5eb336