### PR TITLE
Fix footer layout on reverse additive page

### DIFF
--- a/reverse-additive.html
+++ b/reverse-additive.html
@@ -1460,10 +1460,11 @@
               </div>
             </div>
           </div>
-        </div>
 
-
-              </div>
+          <div
+            class="mt-16 border-t border-slate-200 dark:border-slate-700 pt-10"
+          >
+            <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
               <div>
                 <div class="text-sm font-semibold mb-3">Образование</div>
                 <ul class="space-y-2 text-sm">


### PR DESCRIPTION
## Summary
- reorganized the contacts footer so that the quick-links columns sit inside the main container, eliminating the broken layout on the reverse additive page
- kept the existing contact cards and map tab with their original targets while ensuring consistent styling

## Testing
- No automated tests were run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d3ec67c5108333ac9338baa60fda23