### PR TITLE
Replace Google map with Yandex and add VR tours

### DIFF
--- a/index.html
+++ b/index.html
@@ -1487,56 +1487,120 @@
             </div>
           </div>
           <div
-            class="rounded-3xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-soft"
+            class="rounded-3xl border border-slate-200 dark:border-slate-700 bg-gradient-to-br from-sky-50 via-white to-emerald-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 p-6 shadow-soft"
           >
-            <h3 class="font-semibold mb-2">Адреса</h3>
-            <div
-              class="grid sm:grid-cols-2 gap-4 text-sm text-slate-700 dark:text-slate-200"
-            >
+            <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
               <div>
-                <div class="font-medium">ВДНХ</div>
-                <div>ул. Вильгельма Пика, 4, корп. 8</div>
+                <h3 class="font-semibold text-lg">Адреса и VR‑туры</h3>
+                <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">
+                  Выберите площадку, чтобы посмотреть маршрут на карте или
+                  заглянуть внутрь лабораторий в формате 360°.
+                </p>
               </div>
-              <div>
-                <div class="font-medium">Беговая</div>
-                <div>ул. Беговая, 12</div>
-              </div>
-            </div>
-            <div class="mt-6">
-              <div class="flex items-center gap-2 mb-3">
+              <div
+                class="flex items-center gap-2 rounded-2xl border border-slate-200 dark:border-slate-700 bg-white/80 dark:bg-slate-800/80 p-1"
+              >
                 <button
-                  class="px-3 py-1.5 rounded-xl text-sm border bg-slate-900 text-white dark:bg-white dark:text-slate-900 border-slate-900 dark:border-white"
+                  class="px-3 py-1.5 rounded-xl text-sm font-medium text-white bg-slate-900 dark:bg-white dark:text-slate-900 shadow-sm"
                   data-maptab="0"
                 >
                   ВДНХ
                 </button>
                 <button
-                  class="px-3 py-1.5 rounded-xl text-sm border bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700"
+                  class="px-3 py-1.5 rounded-xl text-sm font-medium text-slate-700 dark:text-slate-200 shadow-sm"
                   data-maptab="1"
                 >
                   Беговая
                 </button>
               </div>
-              <div
-                class="relative w-full overflow-hidden rounded-2xl border border-slate-200 dark:border-slate-700 aspect-video"
-              >
-                <iframe
-                  title="Карта — ВДНХ"
-                  class="absolute inset-0 w-full h-full"
-                  data-map="0"
-                  src="https://www.google.com/maps?q=%D0%9C%D0%BE%D1%81%D0%BA%D0%B2%D0%B0,%20%D1%83%D0%BB.%20%D0%92%D0%B8%D0%BB%D1%8C%D0%B3%D0%B5%D0%BB%D1%8C%D0%BC%D0%B0%20%D0%9F%D0%B8%D0%BA%D0%B0,%204,%20%D0%BA%D0%BE%D1%80%D0%BF.%208&output=embed"
-                  loading="lazy"
-                  referrerpolicy="no-referrer-when-downgrade"
-                ></iframe>
-                <iframe
-                  title="Карта — Беговая"
-                  class="absolute inset-0 w-full h-full opacity-0 pointer-events-none"
-                  data-map="1"
-                  src="https://www.google.com/maps?q=%D0%9C%D0%BE%D1%81%D0%BA%D0%B2%D0%B0,%20%D1%83%D0%BB.%20%D0%91%D0%B5%D0%B3%D0%BE%D0%B2%D0%B0%D1%8F,%2012&output=embed"
-                  loading="lazy"
-                  referrerpolicy="no-referrer-when-downgrade"
-                ></iframe>
+            </div>
+            <div
+              class="mt-6 grid gap-4 sm:grid-cols-2 text-sm text-slate-700 dark:text-slate-200"
+            >
+              <div class="rounded-2xl bg-white/70 dark:bg-slate-800/70 border border-slate-200 dark:border-slate-700 p-4 shadow-sm">
+                <div class="flex items-start justify-between gap-3">
+                  <div>
+                    <div class="font-semibold text-slate-900 dark:text-white">
+                      ВДНХ
+                    </div>
+                    <div>ул. Вильгельма Пика, 4, корп. 8</div>
+                  </div>
+                  <span aria-hidden class="inline-flex size-9 items-center justify-center rounded-xl bg-sky-100 text-sky-600 dark:bg-sky-900/60 dark:text-sky-200">
+                    🧭
+                  </span>
+                </div>
+                <a
+                  href="https://pika.technopark-rgsu.ru/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-sky-600 hover:text-sky-700 dark:text-sky-300 dark:hover:text-sky-200"
+                >
+                  <span>VR‑тур по площадке ВДНХ</span>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    class="h-4 w-4"
+                  >
+                    <path d="M5 12h14" stroke-linecap="round" />
+                    <path d="m13 6 6 6-6 6" stroke-linecap="round" stroke-linejoin="round" />
+                  </svg>
+                </a>
               </div>
+              <div class="rounded-2xl bg-white/70 dark:bg-slate-800/70 border border-slate-200 dark:border-slate-700 p-4 shadow-sm">
+                <div class="flex items-start justify-between gap-3">
+                  <div>
+                    <div class="font-semibold text-slate-900 dark:text-white">
+                      Беговая
+                    </div>
+                    <div>ул. Беговая, 12</div>
+                  </div>
+                  <span aria-hidden class="inline-flex size-9 items-center justify-center rounded-xl bg-emerald-100 text-emerald-600 dark:bg-emerald-900/60 dark:text-emerald-200">
+                    🛰️
+                  </span>
+                </div>
+                <a
+                  href="https://begovaya.technopark-rgsu.ru/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-emerald-600 hover:text-emerald-700 dark:text-emerald-300 dark:hover:text-emerald-200"
+                >
+                  <span>VR‑тур по площадке Беговая</span>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    class="h-4 w-4"
+                  >
+                    <path d="M5 12h14" stroke-linecap="round" />
+                    <path d="m13 6 6 6-6 6" stroke-linecap="round" stroke-linejoin="round" />
+                  </svg>
+                </a>
+              </div>
+            </div>
+            <div
+              class="mt-6 relative w-full overflow-hidden rounded-3xl border border-slate-200 dark:border-slate-700 bg-white/80 dark:bg-slate-900/60 shadow-inner aspect-video"
+            >
+              <iframe
+                title="Карта — ВДНХ"
+                class="absolute inset-0 w-full h-full"
+                data-map="0"
+                src="https://yandex.ru/map-widget/v1/?lang=ru_RU&scroll=false&mode=search&text=%D1%83%D0%BB.%20%D0%92%D0%B8%D0%BB%D1%8C%D0%B3%D0%B5%D0%BB%D1%8C%D0%BC%D0%B0%20%D0%9F%D0%B8%D0%BA%D0%B0,%204,%20%D0%BA%D0%BE%D1%80%D0%BF.%208"
+                loading="lazy"
+                allowfullscreen
+              ></iframe>
+              <iframe
+                title="Карта — Беговая"
+                class="absolute inset-0 w-full h-full opacity-0 pointer-events-none"
+                data-map="1"
+                src="https://yandex.ru/map-widget/v1/?lang=ru_RU&scroll=false&mode=search&text=%D1%83%D0%BB.%20%D0%91%D0%B5%D0%B3%D0%BE%D0%B2%D0%B0%D1%8F,%2012"
+                loading="lazy"
+                allowfullscreen
+              ></iframe>
             </div>
             <div class="mt-4 text-sm text-slate-500 dark:text-slate-400">
               © <span id="y"></span> Технопарк РГСУ
@@ -1980,6 +2044,14 @@
             .querySelectorAll("[data-maptab]")
             .forEach((b) =>
               b.classList.toggle("dark:text-slate-900", b === btn),
+            );
+          document
+            .querySelectorAll("[data-maptab]")
+            .forEach((b) => b.classList.toggle("text-slate-700", b !== btn));
+          document
+            .querySelectorAll("[data-maptab]")
+            .forEach((b) =>
+              b.classList.toggle("dark:text-slate-200", b !== btn),
             );
           document.querySelectorAll("[data-map]").forEach((frame) => {
             frame.classList.toggle("opacity-0", frame.dataset.map !== i);


### PR DESCRIPTION
## Summary
- refresh the contacts card with a softer gradient layout and split address details per location
- add prominent links to the VR tours for the VDNH and Begovaya sites
- swap the embedded Google Maps iframes for Yandex map widgets and update the tab styling logic

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d3f14aa42c83339c505e8610af4054