### PR TITLE
Move partnership note under reverse engineering course

### DIFF
--- a/index.html
+++ b/index.html
@@ -989,22 +989,6 @@
           Учебные планы на 48–72 часа с индивидуальными проектами, подготовка к
           чемпионатам «Профессионалы», WorldSkills, HI‑TECH.
         </p>
-        <details
-          class="mt-4 rounded-2xl border border-slate-200 dark:border-slate-700 p-4 open:shadow-sm"
-        >
-          <summary class="cursor-pointer font-medium">
-            Образовательные проекты совместно с ФГБОУ ВО РГСУ
-          </summary>
-          <ul
-            class="mt-3 list-disc pl-5 text-sm text-slate-700 dark:text-slate-200"
-          >
-            <li>Знакомство со сканерами, подготовка объекта</li>
-            <li>Обработка сеток: чистка, выравнивание, ремешинг</li>
-            <li>Восстановление поверхностей / NURBS</li>
-            <li>CAD‑проектирование и контроль</li>
-            <li>Подготовка к печати, постобработка</li>
-          </ul>
-        </details>
         <div class="mt-8 grid sm:grid-cols-2 gap-6 md:gap-8">
           <a
             class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm hover:shadow-md transition-shadow dark:border-slate-700 dark:bg-slate-800 block focus:outline-none focus:ring-4 focus:ring-slate-200 dark:focus:ring-slate-700"
@@ -1055,6 +1039,9 @@
                     >Студенты и специалисты</span
                   >
                 </div>
+                <p class="mt-3 text-sm text-slate-600 dark:text-slate-200">
+                  Образовательные проекты совместно с ФГБОУ ВО РГСУ
+                </p>
               </div>
               <svg viewBox="0 0 24 24" class="mt-1 h-5 w-5 text-slate-400">
                 <path


### PR DESCRIPTION
## Summary
- remove the expandable block before the course cards
- show the partnership note directly under the reverse engineering course card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3f235c9a4833381dc8234578ddd2d