### PR TITLE
Update education programs section content

### DIFF
--- a/index.html
+++ b/index.html
@@ -1552,7 +1552,7 @@
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-6 mb-10">
           <div>
-            <h2 class="text-3xl md:text-4xl font-bold">Новости и статьи</h2>
+            <h2 class="text-3xl md:text-4xl font-bold">Образовательные программы и статьи</h2>
             <p class="mt-3 text-slate-600 dark:text-slate-300 max-w-2xl">
               Коротко делимся проектами лаборатории, методическими материалами и
               вдохновляющими кейсами индустриального дизайна и инженерии.
@@ -1596,28 +1596,67 @@
                 <time datetime="2024-04-18">18 апреля 2024</time>
               </div>
               <h3 class="mt-4 text-xl font-semibold text-slate-900 dark:text-white">
-                Как мы за 5 дней восстановили 3D‑модель редкой детали
+                «Реверсивный инжиниринг и аддитивное производство»
               </h3>
               <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">
-                Сканирование, облака точек, подготовка поверхности и печать на
-                SLS — рассказываем про рабочий процесс лаборатории шаг за шагом.
+                Образовательные проекты совместно с ФГБОУ ВО РГСУ. Проходим путь
+                от цифрового двойника до запуска аддитивного производства,
+                закрепляя навыки на собственных проектах слушателей.
               </p>
-              <a
-                href="#"
-                class="mt-5 inline-flex items-center gap-2 text-sm font-medium text-sky-600 transition hover:text-sky-500 dark:text-sky-300 dark:hover:text-sky-200"
-              >
-                Читать заметку
-                <svg viewBox="0 0 24 24" class="h-4 w-4">
-                  <path
-                    d="M5 12h13M13 5l7 7-7 7"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.5"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-              </a>
+              <ul class="mt-4 space-y-2 text-sm text-slate-600 dark:text-slate-300">
+                <li>Знакомство с оборудованием, подготовка объекта к сканированию</li>
+                <li>Обработка сеток, ремешинг, контроль качества поверхности</li>
+                <li>CAD‑проектирование, подготовка в CAM и цифровая аттестация</li>
+                <li>Подготовка к печати, постобработка и упаковка кейса для защиты</li>
+              </ul>
+              <div class="mt-5 flex flex-wrap gap-2 text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                <span class="inline-flex items-center rounded-md bg-slate-100 px-2 py-1 dark:bg-slate-700">Сертификат РГСУ</span>
+                <span class="inline-flex items-center rounded-md bg-slate-100 px-2 py-1 dark:bg-slate-700">Проектный трек</span>
+                <span class="inline-flex items-center rounded-md bg-slate-100 px-2 py-1 dark:bg-slate-700">Наставники-практики</span>
+              </div>
+              <div class="mt-5 flex flex-wrap gap-3">
+                <a
+                  href="#"
+                  class="inline-flex items-center justify-center rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:-translate-y-0.5 hover:bg-slate-800 focus:outline-none focus:ring-4 focus:ring-slate-300 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200 dark:focus:ring-slate-700"
+                >
+                  Подобрать программу
+                </a>
+                <a
+                  href="#"
+                  class="inline-flex items-center justify-center rounded-xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-900 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-slate-700 dark:text-slate-100"
+                >
+                  Смотреть подробности
+                </a>
+              </div>
+              <div class="mt-6 space-y-4 rounded-2xl bg-slate-50 p-4 text-sm text-slate-700 dark:bg-slate-900/50 dark:text-slate-200">
+                <div>
+                  <h4 class="font-semibold text-slate-900 dark:text-white">Интенсив «Digital Manufacturing Sprint»</h4>
+                  <p class="mt-1 text-sm">Неделя сжатой практики: от 3D‑сканирования до печати на индустриальном оборудовании с наставником.</p>
+                  <div class="mt-2 flex flex-wrap gap-2 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    <span class="rounded-md bg-white px-2 py-1 shadow-sm dark:bg-slate-800">48 ч</span>
+                    <span class="rounded-md bg-white px-2 py-1 shadow-sm dark:bg-slate-800">Проектная защита</span>
+                    <span class="rounded-md bg-white px-2 py-1 shadow-sm dark:bg-slate-800">Смешанный формат</span>
+                  </div>
+                </div>
+                <div>
+                  <h4 class="font-semibold text-slate-900 dark:text-white">Проектная школа «Advanced CAD/CAE»</h4>
+                  <p class="mt-1 text-sm">Работаем над цифровыми прототипами, осваиваем анализ и оптимизацию конструкции в CAE, завершаем защитой перед индустриальными партнёрами.</p>
+                  <div class="mt-2 flex flex-wrap gap-2 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    <span class="rounded-md bg-white px-2 py-1 shadow-sm dark:bg-slate-800">72 ч</span>
+                    <span class="rounded-md bg-white px-2 py-1 shadow-sm dark:bg-slate-800">Наставники из R22.Lab</span>
+                    <span class="rounded-md bg-white px-2 py-1 shadow-sm dark:bg-slate-800">Командная работа</span>
+                  </div>
+                </div>
+                <div>
+                  <h4 class="font-semibold text-slate-900 dark:text-white">Практикум «Reverse Engineering Lab»</h4>
+                  <p class="mt-1 text-sm">От скана до цифрового двойника: отрабатываем методики контроля, обмеров, реверсивного проектирования и подготовки в CAM.</p>
+                  <div class="mt-2 flex flex-wrap gap-2 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    <span class="rounded-md bg-white px-2 py-1 shadow-sm dark:bg-slate-800">Гибкий график</span>
+                    <span class="rounded-md bg-white px-2 py-1 shadow-sm dark:bg-slate-800">Индивидуальные кейсы</span>
+                    <span class="rounded-md bg-white px-2 py-1 shadow-sm dark:bg-slate-800">Доступ к лаборатории 24/7</span>
+                  </div>
+                </div>
+              </div>
             </div>
           </article>
 


### PR DESCRIPTION
## Summary
- retitle the education/news section to highlight programs alongside articles
- replace the reverse engineering article card with an announcement of the «Реверсивный инжиниринг и аддитивное производство» course
- expand the card content with program bullet points, badges, calls to action, and details on key educational tracks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3f85abe948333992c36657d46c397