### PR TITLE
Fix footer alignment in contact section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1826,7 +1826,7 @@
       class="py-16 md:py-24 border-t border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900"
     >
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="grid md:grid-cols-2 gap-10 items-center">
+        <div class="grid md:grid-cols-2 gap-10 items-start">
           <div>
             <h2 class="text-3xl md:text-4xl font-bold">Контакты</h2>
             <p class="mt-3 text-slate-600 dark:text-slate-300 max-w-prose">

--- a/reverse-additive.html
+++ b/reverse-additive.html
@@ -1072,7 +1072,7 @@
       class="py-16 md:py-24 border-t border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900"
     >
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="grid md:grid-cols-2 gap-10 items-center">
+        <div class="grid md:grid-cols-2 gap-10 items-start">
           <div>
             <h2 class="text-3xl md:text-4xl font-bold">Контакты</h2>
             <p class="mt-3 text-slate-600 dark:text-slate-300 max-w-prose">


### PR DESCRIPTION
## Summary
- align footer contact grid columns to the top instead of vertically centering them on both pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3f740b61c833386a9c456c63aeda8