### PR TITLE
Adjust light backgrounds for Step3D.Lab pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,12 +33,12 @@
       :root {
         color-scheme: light dark;
         --page-gradient-light: radial-gradient(
-            120% 140% at 10% -10%,
-            rgba(14, 165, 233, 0.18),
-            rgba(14, 165, 233, 0)
+            135% 160% at 15% -20%,
+            rgba(125, 211, 252, 0.18),
+            rgba(125, 211, 252, 0)
           ),
-          radial-gradient(140% 120% at 90% 20%, rgba(52, 211, 153, 0.18), rgba(52, 211, 153, 0)),
-          linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+          radial-gradient(150% 130% at 88% 15%, rgba(129, 230, 217, 0.18), rgba(129, 230, 217, 0)),
+          linear-gradient(180deg, #f9fcff 0%, #eef5ff 100%);
         --page-gradient-dark: radial-gradient(
             120% 140% at 12% -10%,
             rgba(56, 189, 248, 0.26),
@@ -78,29 +78,29 @@
 
       body::before {
         background: radial-gradient(
-            40% 40% at 20% 15%,
-            rgba(59, 130, 246, 0.24),
-            rgba(59, 130, 246, 0)
+            42% 42% at 22% 12%,
+            rgba(148, 197, 255, 0.22),
+            rgba(148, 197, 255, 0)
           ),
           radial-gradient(
-            32% 32% at 75% 18%,
-            rgba(16, 185, 129, 0.2),
-            rgba(16, 185, 129, 0)
+            34% 34% at 74% 18%,
+            rgba(129, 230, 217, 0.18),
+            rgba(129, 230, 217, 0)
           ),
-          radial-gradient(45% 55% at 50% 80%, rgba(14, 165, 233, 0.12), transparent);
+          radial-gradient(48% 58% at 50% 78%, rgba(191, 219, 254, 0.12), transparent);
         filter: blur(0);
-        opacity: 0.85;
+        opacity: 0.8;
       }
 
       body::after {
         background-image: linear-gradient(
-            rgba(148, 163, 184, 0.08) 1px,
+            rgba(148, 163, 184, 0.06) 1px,
             transparent 1px
           ),
-          linear-gradient(90deg, rgba(148, 163, 184, 0.08) 1px, transparent 1px);
+          linear-gradient(90deg, rgba(148, 163, 184, 0.06) 1px, transparent 1px);
         background-size: 60px 60px;
         mask-image: radial-gradient(60% 60% at 50% 45%, rgba(0, 0, 0, 0.55), transparent);
-        opacity: 0.65;
+        opacity: 0.55;
       }
 
       @media (prefers-color-scheme: dark) {
@@ -504,10 +504,10 @@
     <header class="relative overflow-hidden">
       <div class="absolute inset-0 pointer-events-none">
         <div
-          class="absolute -top-24 -right-16 h-72 w-72 rounded-full bg-sky-300/30 blur-3xl"
+          class="absolute -top-24 -right-16 h-72 w-72 rounded-full bg-sky-200/30 blur-3xl"
         ></div>
         <div
-          class="absolute -bottom-24 -left-16 h-72 w-72 rounded-full bg-emerald-300/30 blur-3xl"
+          class="absolute -bottom-24 -left-16 h-72 w-72 rounded-full bg-emerald-200/30 blur-3xl"
         ></div>
       </div>
 

--- a/reverse-additive.html
+++ b/reverse-additive.html
@@ -33,12 +33,12 @@
       :root {
         color-scheme: light dark;
         --page-gradient-light: radial-gradient(
-            120% 140% at 12% -10%,
-            rgba(14, 165, 233, 0.18),
-            rgba(14, 165, 233, 0)
+            135% 155% at 14% -15%,
+            rgba(125, 211, 252, 0.18),
+            rgba(125, 211, 252, 0)
           ),
-          radial-gradient(140% 120% at 90% 10%, rgba(52, 211, 153, 0.18), rgba(52, 211, 153, 0)),
-          linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+          radial-gradient(145% 125% at 88% 8%, rgba(129, 230, 217, 0.18), rgba(129, 230, 217, 0)),
+          linear-gradient(180deg, #f9fcff 0%, #eef5ff 100%);
         --page-gradient-dark: radial-gradient(
             120% 140% at 12% -10%,
             rgba(59, 130, 246, 0.24),
@@ -78,28 +78,28 @@
 
       body::before {
         background: radial-gradient(
-            40% 40% at 20% 12%,
-            rgba(59, 130, 246, 0.26),
-            rgba(59, 130, 246, 0)
+            42% 42% at 22% 10%,
+            rgba(148, 197, 255, 0.22),
+            rgba(148, 197, 255, 0)
           ),
           radial-gradient(
-            38% 38% at 78% 16%,
-            rgba(16, 185, 129, 0.2),
-            rgba(16, 185, 129, 0)
+            36% 36% at 78% 14%,
+            rgba(129, 230, 217, 0.18),
+            rgba(129, 230, 217, 0)
           ),
-          radial-gradient(45% 60% at 50% 82%, rgba(14, 165, 233, 0.12), transparent);
-        opacity: 0.8;
+          radial-gradient(48% 58% at 50% 80%, rgba(191, 219, 254, 0.12), transparent);
+        opacity: 0.78;
       }
 
       body::after {
         background-image: linear-gradient(
-            rgba(148, 163, 184, 0.08) 1px,
+            rgba(148, 163, 184, 0.06) 1px,
             transparent 1px
           ),
-          linear-gradient(90deg, rgba(148, 163, 184, 0.08) 1px, transparent 1px);
+          linear-gradient(90deg, rgba(148, 163, 184, 0.06) 1px, transparent 1px);
         background-size: 60px 60px;
         mask-image: radial-gradient(65% 65% at 50% 45%, rgba(0, 0, 0, 0.55), transparent);
-        opacity: 0.6;
+        opacity: 0.52;
       }
 
       @media (prefers-color-scheme: dark) {
@@ -367,10 +367,10 @@
     <header class="relative overflow-hidden">
       <div class="absolute inset-0 pointer-events-none">
         <div
-          class="absolute -top-32 -right-24 h-80 w-80 rounded-full bg-sky-300/25 blur-3xl"
+          class="absolute -top-32 -right-24 h-80 w-80 rounded-full bg-sky-200/25 blur-3xl"
         ></div>
         <div
-          class="absolute -bottom-32 -left-24 h-80 w-80 rounded-full bg-emerald-300/25 blur-3xl"
+          class="absolute -bottom-32 -left-24 h-80 w-80 rounded-full bg-emerald-200/25 blur-3xl"
         ></div>
       </div>
 


### PR DESCRIPTION
## Summary
- soften the light-mode page gradients on the home and course pages to keep the background bright and airy
- lighten the decorative hero overlays so they match the refreshed gradient palette

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d3fb159400833383188412c745b2ee