### PR TITLE
feat: add base styling and modernize team section

### DIFF
--- a/assets/styles/base.css
+++ b/assets/styles/base.css
@@ -1,0 +1,239 @@
+/* Base styles and design tokens for Step3D.Lab */
+:root {
+  color-scheme: dark;
+  --font-sans: system-ui, -apple-system, "Segoe UI", "Roboto", "Inter", Arial, sans-serif;
+  --bg: #0b0d12;
+  --card: #0f1218;
+  --fg: #e8eef7;
+  --muted: #98a2b3;
+  --primary: #6ea8fe;
+  --accent: #3dd2ad;
+  --radius: 16px;
+  --shadow: 0 18px 48px rgba(0, 0, 0, 0.3);
+  --border-subtle: rgba(255, 255, 255, 0.08);
+  --container-padding: 1rem;
+}
+
+* {
+  box-sizing: border-box;
+  min-width: 0;
+}
+
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
+html {
+  scroll-behavior: smooth;
+  background-color: var(--bg);
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--fg);
+  background-color: var(--bg);
+}
+
+img,
+svg,
+video {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+img {
+  border-radius: 0;
+}
+
+figure {
+  margin: 0;
+}
+
+ul,
+ol {
+  margin-block: 0 1rem;
+  margin-inline-start: 1.25rem;
+  padding: 0;
+}
+
+li {
+  margin-block-end: 0.35rem;
+}
+
+p {
+  margin-block: 0 1rem;
+}
+
+a {
+  color: var(--primary);
+  text-decoration: none;
+  transition: color 0.2s ease, text-decoration-color 0.2s ease;
+}
+
+a:hover {
+  color: #9dc2ff;
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+}
+
+:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.container {
+  width: min(100%, 78.75rem);
+  margin-inline: auto;
+  padding-inline: var(--container-padding);
+}
+
+.section {
+  padding-block: 3rem;
+}
+
+.section-title {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.5rem, 1.5vw + 1rem, 2.25rem);
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.section-lead {
+  margin: 0 0 1.5rem;
+  color: var(--muted);
+  max-width: 62ch;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.grid.cols-2 {
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.grid.cols-3 {
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  background-color: var(--card);
+  border-radius: var(--radius);
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow);
+  color: var(--fg);
+  overflow: hidden;
+}
+
+.card-media {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+}
+
+.card-media > img,
+.card-media > picture {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem 1.5rem;
+}
+
+.card-title {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: clamp(1.25rem, 1vw + 1rem, 1.75rem);
+  font-weight: 700;
+}
+
+.card-text {
+  margin: 0;
+  color: var(--muted);
+}
+
+.card-actions {
+  margin-top: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.625rem 0.95rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--fg);
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.btn-primary {
+  background: linear-gradient(180deg, rgba(110, 168, 254, 0.18), rgba(110, 168, 254, 0.06));
+  border-color: rgba(110, 168, 254, 0.35);
+}
+
+.icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  flex: 0 0 auto;
+}
+
+@media (min-width: 48rem) {
+  :root {
+    --container-padding: 1.5rem;
+  }
+
+  .section {
+    padding-block: 4rem;
+  }
+}
+
+@media (min-width: 64rem) {
+  :root {
+    --container-padding: 2rem;
+  }
+
+  .section {
+    padding-block: 4.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/assets/styles/components.css
+++ b/assets/styles/components.css
@@ -1,0 +1,224 @@
+/* Component-level styles for Step3D.Lab */
+.muted {
+  color: var(--muted);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--fg);
+}
+
+.btn-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--fg);
+  font-size: 1.125rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn-icon:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.3);
+}
+
+.team-section {
+  position: relative;
+}
+
+.team-section::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(120% 120% at 10% 0%, rgba(110, 168, 254, 0.18), transparent 65%),
+    radial-gradient(80% 80% at 90% 10%, rgba(61, 210, 173, 0.16), transparent 70%);
+  opacity: 0.6;
+  pointer-events: none;
+  z-index: -2;
+}
+
+.team-section .container {
+  position: relative;
+  z-index: 1;
+}
+
+.team-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 36rem) {
+  .team-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 64rem) {
+  .team-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.team-card {
+  padding: 1.5rem;
+  gap: 1.5rem;
+  background: linear-gradient(135deg, rgba(15, 18, 24, 0.95), rgba(15, 18, 24, 0.75));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 20px 45px rgba(4, 8, 15, 0.4);
+}
+
+.team-card__header {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.avatar {
+  width: 7rem;
+  height: 7rem;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid rgba(255, 255, 255, 0.14);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
+}
+
+.team-card__summary {
+  display: grid;
+  gap: 0.35rem;
+  flex: 1 1 auto;
+}
+
+.team-card__name {
+  margin: 0;
+  font-size: clamp(1.125rem, 1vw + 1rem, 1.5rem);
+  font-weight: 700;
+}
+
+.team-card__role {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.team-card__focus {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(232, 238, 247, 0.8);
+}
+
+.team-card__actions {
+  margin-left: auto;
+}
+
+.team-card__details {
+  padding-top: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.team-card__list {
+  list-style: disc;
+  margin-inline-start: 1.25rem;
+  color: rgba(232, 238, 247, 0.88);
+}
+
+.team-card__list > li {
+  margin-bottom: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.team-card__label {
+  font-weight: 600;
+  color: var(--fg);
+}
+
+.team-card__list ul {
+  list-style: disc;
+  margin-block-start: 0.35rem;
+  margin-inline-start: 1.25rem;
+}
+
+.placeholder {
+  color: rgba(232, 238, 247, 0.38);
+  font-style: italic;
+}
+
+.surface-panel {
+  border-radius: var(--radius);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(12, 14, 20, 0.75);
+  padding: 1.5rem;
+  backdrop-filter: blur(12px);
+}
+
+.accordion {
+  border-radius: var(--radius);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  overflow: hidden;
+}
+
+.accordion summary {
+  cursor: pointer;
+  padding: 1rem 1.25rem;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.accordion summary:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.accordion[open] summary {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.accordion__panel {
+  padding: 1rem 1.25rem 1.25rem;
+  color: rgba(232, 238, 247, 0.85);
+}
+
+.tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.tabs__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tabs__trigger {
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--fg);
+  font-weight: 600;
+}
+
+.tabs__trigger[aria-selected="true"] {
+  background: rgba(110, 168, 254, 0.18);
+  border-color: rgba(110, 168, 254, 0.45);
+}
+
+.tabs__panel {
+  display: none;
+}
+
+.tabs__panel[aria-hidden="false"] {
+  display: block;
+}

--- a/index.html
+++ b/index.html
@@ -20,6 +20,9 @@
       href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><rect x='6' y='6' width='52' height='52' rx='12' fill='%230ea5e9'/><path d='M20 44V20l12-6 12 6v24l-12 6-12-6z M32 14v36' stroke='%23fff' stroke-width='2' fill='none'/></svg>"
     />
 
+    <link rel="stylesheet" href="assets/styles/base.css" />
+    <link rel="stylesheet" href="assets/styles/components.css" />
+
     <style>
       :root {
         color-scheme: light dark;
@@ -1675,82 +1678,75 @@
     </section>
 
     <!-- Команда -->
-    <section id="team" class="section-shell py-16 md:py-24">
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 space-y-10">
-        <h2 class="text-balance-2 font-bold">Команда</h2>
-        <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
-          <article
-            class="surface-card-base rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800"
-          >
-            <div class="flex items-start gap-4">
+    <section id="team" class="section team-section">
+      <div class="container">
+        <h2 class="section-title">Команда</h2>
+        <div class="team-grid">
+          <article class="card team-card">
+            <div class="team-card__header">
               <img
                 src="assets/images/index/team/vladimir-ganishin.svg"
                 alt="Владимир Ганьшин"
-                class="h-16 w-16 rounded-2xl border border-slate-200 object-cover shadow-sm dark:border-slate-600"
+                class="avatar"
                 loading="lazy"
+                decoding="async"
               />
-              <div class="flex-1">
-                <div class="flex items-start justify-between gap-3">
-                  <div>
-                    <div class="font-semibold text-lg">Владимир Ганьшин</div>
-                    <div class="text-sm text-slate-600 dark:text-slate-200">
-                      руководитель лаборатории
-                    </div>
-                    <div class="mt-1 text-sm text-slate-700 dark:text-slate-200">
-                      CAD/AM, реверс, методология ДПО
-                    </div>
-                  </div>
-                  <button
-                    type="button"
-                    class="team-toggle inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-slate-300 text-lg font-semibold text-slate-700 transition hover:-translate-y-0.5 hover:border-slate-400 hover:text-slate-900 dark:border-slate-600 dark:text-slate-200 dark:hover:border-slate-500 dark:hover:text-white"
-                    aria-expanded="false"
-                    aria-controls="team-details-ganishin"
-                    data-team-toggle="team-details-ganishin"
-                  >
-                    <span aria-hidden="true" data-state-icon>+</span>
-                    <span class="sr-only">Показать подробности о Владимире Ганьшине</span>
-                  </button>
-                </div>
+              <div class="team-card__summary">
+                <h3 class="team-card__name">Владимир Ганьшин</h3>
+                <p class="team-card__role">руководитель лаборатории</p>
+                <p class="team-card__focus">CAD/AM, реверс, методология ДПО</p>
+              </div>
+              <div class="team-card__actions">
+                <button
+                  type="button"
+                  class="team-toggle btn-icon"
+                  aria-expanded="false"
+                  aria-controls="team-details-ganishin"
+                  data-team-toggle="team-details-ganishin"
+                >
+                  <span aria-hidden="true" data-state-icon>+</span>
+                  <span class="sr-only">Показать подробности о Владимире Ганьшине</span>
+                </button>
               </div>
             </div>
-            <div id="team-details-ganishin" class="mt-4 hidden" aria-hidden="true">
-              <ul class="space-y-3 text-sm text-slate-700 dark:text-slate-200">
-                <li><span class="font-medium text-slate-900 dark:text-white">Возраст и город:</span> 34 года, Москва.</li>
+            <div id="team-details-ganishin" class="team-card__details hidden" aria-hidden="true">
+              <ul class="team-card__list">
+                <li><span class="team-card__label">Возраст и город:</span> 34 года, Москва.</li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Должности:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Должности:</span>
+                  <ul>
                     <li>Руководитель технопарка ФГБОУ РГСУ (2019 — н.в.).</li>
                     <li>Преподаватель РГСУ, филиал в г. Пятигорске (2024 — н.в.).</li>
                   </ul>
                 </li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Образование:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Образование:</span>
+                  <ul>
                     <li>МГТУ «Станкин», бакалавриат «Технология, оборудование и автоматизация машиностроительных производств» (2008–2012).</li>
                     <li>МГТУ «Станкин», магистратура «Конструкторско-технологическое обеспечение машиностроительных производств» (2012–2014).</li>
                     <li>Аспирантура по направлению 05.02.07 «Технология и оборудование механической и физико-технической обработки», квалификация преподаватель-исследователь высшей школы (2014–2018).</li>
                   </ul>
                 </li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Педагогический стаж &gt;10 лет:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Педагогический стаж &gt;10 лет:</span>
+                  <ul>
                     <li>
                       ВУЗы:
-                      <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400/80">
+                      <ul>
                         <li>МГТУ «Станкин», кафедра «ИТиТФ» (2014–2018).</li>
                         <li>Российский государственный социальный университет, факультет информационных технологий (2018 — н.в.).</li>
                       </ul>
                     </li>
                     <li>
                       СУЗы:
-                      <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400/80">
+                      <ul>
                         <li>Политехнический колледж № 42 — мастер производственного обучения (2014).</li>
                         <li>Западный комплекс непрерывного образования — преподаватель специальных дисциплин (2015–2018).</li>
                       </ul>
                     </li>
                     <li>
                       Школы:
-                      <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400/80">
+                      <ul>
                         <li>ЗКНО — уроки технологии по 3D-моделированию (2017–2018).</li>
                         <li>«Марьина Роща им. Орлова» — курсы «Промышленный дизайн» и «Прототипирование» (2021–2022).</li>
                       </ul>
@@ -1759,8 +1755,8 @@
                   </ul>
                 </li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Преподаваемые курсы:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Преподаваемые курсы:</span>
+                  <ul>
                     <li>«Промышленный дизайн и инжиниринг» (разработчик).</li>
                     <li>«Инженерный дизайн (САПР)» (разработчик).</li>
                     <li>«Реверсивный инжиниринг и технологии аддитивного производства» (соавтор).</li>
@@ -1768,16 +1764,16 @@
                   </ul>
                 </li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Программное обеспечение и оборудование:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Программное обеспечение и оборудование:</span>
+                  <ul>
                     <li>САПР: Autodesk Inventor, Fusion 360, T-FLEX CAD, КОМПАС-3D, Geomagic Design X, GOM Inspect и др.</li>
                     <li>Оборудование: 3D-сканеры RangeVision, Artec Eva, Leica; 3D-принтеры (FDM, DLP, SLA); станки лазерной резки и механообрабатывающие станки с ЧПУ.</li>
                     <li>Языки программирования: C++, Python и др.</li>
                   </ul>
                 </li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Достижения и тренерский опыт:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Достижения и тренерский опыт:</span>
+                  <ul>
                     <li>Тренер сборной России по компетенции «Реверсивный инжиниринг» (WorldSkills): 3 место — Казань 2019, 1 место — BRICS 2020.</li>
                     <li>Подготовил четырёх чемпионов России по WorldSkills (2018–2021) и двух призёров движения «Профессионалы» (2023–2025).</li>
                     <li>Главный эксперт конкурсов (WorldSkills, «Абилимпикс», «Профессионалы», HI-TECH) в 2018–2023.</li>
@@ -1785,93 +1781,86 @@
                   </ul>
                 </li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Учебно-методические материалы и интервью:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
-                    <li>Видео-цикл «Методология проведения курсов ДПО по техническим дисциплинам» (<a class="text-sky-600 hover:text-sky-500 dark:text-sky-300 dark:hover:text-sky-200" href="https://surl.lu/xcfxzz" target="_blank" rel="noopener noreferrer">ссылка</a>).</li>
+                  <span class="team-card__label">Учебно-методические материалы и интервью:</span>
+                  <ul>
+                    <li>Видео-цикл «Методология проведения курсов ДПО по техническим дисциплинам» (<a href="https://surl.lu/xcfxzz" target="_blank" rel="noopener noreferrer">ссылка</a>).</li>
                     <li>Интервью: «Онлайн-экскурсия в социальный университет РГСУ», «Что такое технопарк РГСУ?».</li>
                   </ul>
                 </li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Проекты и портфолио:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Проекты и портфолио:</span>
+                  <ul>
                     <li>Композиционный обвес для Kawasaki Puccetti Racing совместно с Umatex (Росатом).</li>
-                    <li>Telegram-канал: <a class="text-sky-600 hover:text-sky-500 dark:text-sky-300 dark:hover:text-sky-200" href="https://t.me/step_3d_mngr" target="_blank" rel="noopener noreferrer">t.me/step_3d_mngr</a>.</li>
+                    <li>Telegram-канал: <a href="https://t.me/step_3d_mngr" target="_blank" rel="noopener noreferrer">t.me/step_3d_mngr</a>.</li>
                   </ul>
                 </li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Увлечения и контакты:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Увлечения и контакты:</span>
+                  <ul>
                     <li>Шахматы, футбол, искусственный интеллект.</li>
-                    <li>E-mail: <a class="text-sky-600 hover:text-sky-500 dark:text-sky-300 dark:hover:text-sky-200" href="mailto:projects.step3d@gmail.com">projects.step3d@gmail.com</a>.</li>
+                    <li>E-mail: <a href="mailto:projects.step3d@gmail.com">projects.step3d@gmail.com</a>.</li>
                   </ul>
                 </li>
               </ul>
             </div>
           </article>
-          <article
-            class="surface-card-base rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800"
-          >
-            <div class="flex items-start gap-4">
+          <article class="card team-card">
+            <div class="team-card__header">
               <img
                 src="assets/images/index/team/anna-ponkratova.svg"
                 alt="Анна Понкратова"
-                class="h-16 w-16 rounded-2xl border border-slate-200 object-cover shadow-sm dark:border-slate-600"
+                class="avatar"
                 loading="lazy"
+                decoding="async"
               />
-              <div class="flex-1">
-                <div class="flex items-start justify-between gap-3">
-                  <div>
-                    <div class="font-semibold text-lg">Анна Понкратова</div>
-                    <div class="text-sm text-slate-600 dark:text-slate-200">
-                      ведущий инженер‑преподаватель
-                    </div>
-                    <div class="mt-1 text-sm text-slate-700 dark:text-slate-200">
-                      3D‑сканирование, обработка сеток
-                    </div>
-                  </div>
-                  <button
-                    type="button"
-                    class="team-toggle inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-slate-300 text-lg font-semibold text-slate-700 transition hover:-translate-y-0.5 hover:border-slate-400 hover:text-slate-900 dark:border-slate-600 dark:text-slate-200 dark:hover:border-slate-500 dark:hover:text-white"
-                    aria-expanded="false"
-                    aria-controls="team-details-ponkratova"
-                    data-team-toggle="team-details-ponkratova"
-                  >
-                    <span aria-hidden="true" data-state-icon>+</span>
-                    <span class="sr-only">Показать подробности об Анне Понкратовой</span>
-                  </button>
-                </div>
+              <div class="team-card__summary">
+                <h3 class="team-card__name">Анна Понкратова</h3>
+                <p class="team-card__role">ведущий инженер‑преподаватель</p>
+                <p class="team-card__focus">3D‑сканирование, обработка сеток</p>
+              </div>
+              <div class="team-card__actions">
+                <button
+                  type="button"
+                  class="team-toggle btn-icon"
+                  aria-expanded="false"
+                  aria-controls="team-details-ponkratova"
+                  data-team-toggle="team-details-ponkratova"
+                >
+                  <span aria-hidden="true" data-state-icon>+</span>
+                  <span class="sr-only">Показать подробности об Анне Понкратовой</span>
+                </button>
               </div>
             </div>
-            <div id="team-details-ponkratova" class="mt-4 hidden" aria-hidden="true">
-              <ul class="space-y-3 text-sm text-slate-700 dark:text-slate-200">
-                <li><span class="font-medium text-slate-900 dark:text-white">Полное имя:</span> Понкратова Христина Анатольевна.</li>
-                <li><span class="font-medium text-slate-900 dark:text-white">Возраст:</span> 23 года.</li>
+            <div id="team-details-ponkratova" class="team-card__details hidden" aria-hidden="true">
+              <ul class="team-card__list">
+                <li><span class="team-card__label">Полное имя:</span> Понкратова Христина Анатольевна.</li>
+                <li><span class="team-card__label">Возраст:</span> 23 года.</li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Образование:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Образование:</span>
+                  <ul>
                     <li>РУДН, факультет ФМиЕН — бакалавриат «Прикладная математика и информатика» (2020–2024).</li>
                     <li>Университет «Синергия», факультет «Дизайн» — магистратура «Дизайн и продвижение цифрового продукта» (2024 — н.в.).</li>
                   </ul>
                 </li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Место работы:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Место работы:</span>
+                  <ul>
                     <li>Технопарк РГСУ — учебный мастер.</li>
                   </ul>
                 </li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Педагогический стаж &gt;5 лет:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Педагогический стаж &gt;5 лет:</span>
+                  <ul>
                     <li>
                       СУЗы:
-                      <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400/80">
+                      <ul>
                         <li>Первый Московский образовательный комплекс — мастер производственного обучения (аддитивное производство, подготовка к «Московским мастерам», 2023–2025).</li>
                         <li>Западный комплекс непрерывного образования — лаборант лаборатории широкополосных систем радиосвязи, кружок по 3D-моделированию (2019–2020).</li>
                       </ul>
                     </li>
                     <li>
                       Школы:
-                      <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400/80">
+                      <ul>
                         <li>Школа № 1287 — преподаватель допобразования, 3D-моделирование (6–11 классы, 2022–2024).</li>
                         <li>«Марьина Роща им. Орлова» — преподаватель ДО, подготовка к «Московским мастерам», 3D-моделирование (5–11 классы, 2021–2024).</li>
                       </ul>
@@ -1879,15 +1868,15 @@
                   </ul>
                 </li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Компетенции:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Компетенции:</span>
+                  <ul>
                     <li>Реверсивный инжиниринг и изготовление индивидуальных имплантов.</li>
                     <li>Аддитивное производство, инженерный дизайн САПР, биопротезирование.</li>
                   </ul>
                 </li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Программное обеспечение:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Программное обеспечение:</span>
+                  <ul>
                     <li>САПР: КОМПАС-3D, Geomagic Design X, Autodesk Inventor Professional 2018+, Fusion 360, GOM Inspect 2018+, Geomagic Control X, Materialise 3-matic и др.</li>
                     <li>Blender.</li>
                     <li>Слайсеры: Ultimaker Cura, Polygon X, Creality Slicer и др.</li>
@@ -1896,8 +1885,8 @@
                   </ul>
                 </li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Достижения:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Достижения:</span>
+                  <ul>
                     <li>Чемпион финала VII Национального чемпионата «Молодые профессионалы» (WorldSkills Russia 2019) по реверсивному инжинирингу.</li>
                     <li>Чемпион BRICS Skills Challenge 2019 (FutureSkills, реверсивный инжиниринг).</li>
                     <li>Призёр WorldSkills HI-TECH 2018, чемпион WorldSkills HI-TECH 2019.</li>
@@ -1905,87 +1894,80 @@
                     <li>Лауреат гранта Правительства Москвы в сфере образования (2024).</li>
                   </ul>
                 </li>
-                <li><span class="font-medium text-slate-900 dark:text-white">Увлечения:</span> музыка, программирование, спорт.</li>
+                <li><span class="team-card__label">Увлечения:</span> музыка, программирование, спорт.</li>
               </ul>
             </div>
           </article>
-          <article
-            class="surface-card-base rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800"
-          >
-            <div class="flex items-start gap-4">
+          <article class="card team-card">
+            <div class="team-card__header">
               <img
                 src="assets/images/index/team/alexey-rekut.svg"
                 alt="Алексей Рекут"
-                class="h-16 w-16 rounded-2xl border border-slate-200 object-cover shadow-sm dark:border-slate-600"
+                class="avatar"
                 loading="lazy"
+                decoding="async"
               />
-              <div class="flex-1">
-                <div class="flex items-start justify-between gap-3">
-                  <div>
-                    <div class="font-semibold text-lg">Алексей Рекут</div>
-                    <div class="text-sm text-slate-600 dark:text-slate-200">
-                      инженер‑конструктор
-                    </div>
-                    <div class="mt-1 text-sm text-slate-700 dark:text-slate-200">
-                      CAD, ЧПУ, прототипы
-                    </div>
-                  </div>
-                  <button
-                    type="button"
-                    class="team-toggle inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-slate-300 text-lg font-semibold text-slate-700 transition hover:-translate-y-0.5 hover:border-slate-400 hover:text-slate-900 dark:border-slate-600 dark:text-slate-200 dark:hover:border-slate-500 dark:hover:text-white"
-                    aria-expanded="false"
-                    aria-controls="team-details-rekut"
-                    data-team-toggle="team-details-rekut"
-                  >
-                    <span aria-hidden="true" data-state-icon>+</span>
-                    <span class="sr-only">Показать подробности об Алексее Рекуте</span>
-                  </button>
-                </div>
+              <div class="team-card__summary">
+                <h3 class="team-card__name">Алексей Рекут</h3>
+                <p class="team-card__role">инженер‑конструктор</p>
+                <p class="team-card__focus">CAD, ЧПУ, прототипы</p>
+              </div>
+              <div class="team-card__actions">
+                <button
+                  type="button"
+                  class="team-toggle btn-icon"
+                  aria-expanded="false"
+                  aria-controls="team-details-rekut"
+                  data-team-toggle="team-details-rekut"
+                >
+                  <span aria-hidden="true" data-state-icon>+</span>
+                  <span class="sr-only">Показать подробности об Алексее Рекуте</span>
+                </button>
               </div>
             </div>
-            <div id="team-details-rekut" class="mt-4 hidden" aria-hidden="true">
-              <ul class="space-y-3 text-sm text-slate-700 dark:text-slate-200">
-                <li><span class="font-medium text-slate-900 dark:text-white">Возраст:</span> 54 года.</li>
+            <div id="team-details-rekut" class="team-card__details hidden" aria-hidden="true">
+              <ul class="team-card__list">
+                <li><span class="team-card__label">Возраст:</span> 54 года.</li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Должности:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Должности:</span>
+                  <ul>
                     <li>Заместитель руководителя технопарка (2022 — н.в.).</li>
                   </ul>
                 </li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Разработчик программ:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Разработчик программ:</span>
+                  <ul>
                     <li>Программа ДПК преподавателей «Практика и методика реализации образовательных программ основного и среднего общего образования по предмету труд (технологии) на основе проектов спортивно-боевого роботостроения».</li>
                     <li>Дополнительная общеразвивающая программа «Спортивно-боевое роботостроение».</li>
                   </ul>
                 </li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Образование:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Образование:</span>
+                  <ul>
                     <li>Высшее: ГАУ им. Серго Орджоникидзе, «Экономическая кибернетика» (1994).</li>
                     <li>Повышение квалификации: АНХ при Правительстве РФ, «Управление в маркетинге» (2004).</li>
                     <li>Повышение квалификации: СКФУ, «Преподаватель высшей школы» (2017).</li>
                   </ul>
                 </li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Педагогический стаж &gt;9 лет:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Педагогический стаж &gt;9 лет:</span>
+                  <ul>
                     <li>ВУЗ: РГСУ, технопарк (2022 — н.в.).</li>
                     <li>СУЗ: ГАПОУ Колледж предпринимательства №11 (2009–2020).</li>
                     <li>ДПО: ГАПОУ Колледж предпринимательства №11 (2009–2015).</li>
                   </ul>
                 </li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Компетенции:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Компетенции:</span>
+                  <ul>
                     <li>Аддитивное производство (3D-печать FDM, DLP, SLA).</li>
                     <li>Реверсивный инжиниринг.</li>
                     <li>Промышленный дизайн и прототипирование (включая станки с ЧПУ).</li>
                   </ul>
                 </li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Программное обеспечение:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Программное обеспечение:</span>
+                  <ul>
                     <li>САПР: Rhino 3D, Geomagic Design X, GOM Inspect.</li>
                     <li>Слайсеры: Ultimaker Cura, CHITUBOX, Polygon X, Creality Slicer.</li>
                     <li>ПО 3D-сканирования: Artec Studio 15 Professional+, RV 3D Studio (до 2023 — ScanCenter NG).</li>
@@ -1993,8 +1975,8 @@
                   </ul>
                 </li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Достижения:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Достижения:</span>
+                  <ul>
                     <li>Инициатор создания ФГОС СПО «Аддитивные технологии» (соавтор первой редакции, 2010–2013).</li>
                     <li>Создатель компетенций «Реверсивный инжиниринг» (WorldSkills Russia, 2014) и «Additive Manufacturing» (WorldSkills, 2020).</li>
                     <li>Менеджер компетенции «Реверсивный инжиниринг» в WorldSkills/Агентстве развития профессий и навыков (2014 — н.в.).</li>
@@ -2003,20 +1985,19 @@
                   </ul>
                 </li>
                 <li>
-                  <span class="font-medium text-slate-900 dark:text-white">Учебные материалы и интервью:</span>
-                  <ul class="mt-1 ml-4 list-disc space-y-1 marker:text-slate-400">
+                  <span class="team-card__label">Учебные материалы и интервью:</span>
+                  <ul>
                     <li>«Учебное пособие по Rhinoceros 3D», «Базовый курс Rhinoceros 3D».</li>
                     <li>Интервью: фильм «Лучший по профессии» (Россия 24), канал «Аддитивная кухня», 4 канал (Екатеринбург).</li>
                   </ul>
                 </li>
-                <li><span class="font-medium text-slate-900 dark:text-white">Увлечения:</span> механика, кинетическая скульптура, креативная механика, спортивно-боевые роботы.</li>
+                <li><span class="team-card__label">Увлечения:</span> механика, кинетическая скульптура, креативная механика, спортивно-боевые роботы.</li>
               </ul>
             </div>
           </article>
         </div>
       </div>
     </section>
-
     <!-- Новости и статьи -->
     <section id="blog" class="section-shell py-16 md:py-24">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/reverse-additive.html
+++ b/reverse-additive.html
@@ -38,6 +38,8 @@
     />
     <link rel="stylesheet" href="assets/styles/tailwind.css" />
     <link rel="stylesheet" href="assets/styles/site.css" />
+    <link rel="stylesheet" href="assets/styles/base.css" />
+    <link rel="stylesheet" href="assets/styles/components.css" />
 
     <style>
       :root {


### PR DESCRIPTION
## Summary
- introduce `assets/styles/base.css` with design tokens, layout primitives, and shared UI utilities
- add `assets/styles/components.css` covering team cards, buttons, and reusable component patterns
- hook the new styles into both HTML entry points and rebuild the "Команда" section to use the refreshed card layout

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d40387a1148333b91fe4cdad31b356