### PR TITLE
Update reverse course page layout and footer details

### DIFF
--- a/index.html
+++ b/index.html
@@ -1563,7 +1563,7 @@
                 >Написать нам в телеграм</a
               >
               <button id="shareLink" type="button" class="btn btn-outline">
-                Поделиться ссылкой
+                Поделиться ↗
               </button>
             </div>
 

--- a/reverse-additive.html
+++ b/reverse-additive.html
@@ -4,7 +4,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>
-      Step3D.Lab — Курс «Реверсивный инжиниринг и аддитивное производство»
+      Step3D.Lab — Курс R22.АТ.01 «Реверсивный инжиниринг и аддитивное
+      производство»
     </title>
     <meta
       name="description"
@@ -13,19 +14,21 @@
 
     <meta
       property="og:title"
-      content="Step3D.Lab — Курс «Реверсивный инжиниринг и аддитивное производство»"
+      content="Step3D.Lab — Курс R22.АТ.01 «Реверсивный инжиниринг и аддитивное производство»"
     />
     <meta
       property="og:description"
-
+      content="Практический курс ДПО Step3D.Lab: реверсивный инжиниринг, 3D-сканирование, CAD и аддитивное производство."
+    />
     <meta name="twitter:card" content="summary_large_image" />
     <meta
       name="twitter:title"
-      content="Step3D.Lab — Курс «Реверсивный инжиниринг и аддитивное производство»"
+      content="Step3D.Lab — Курс R22.АТ.01 «Реверсивный инжиниринг и аддитивное производство»"
     />
     <meta
       name="twitter:description"
-
+      content="Практический курс ДПО Step3D.Lab: реверсивный инжиниринг, 3D-сканирование, CAD и аддитивное производство."
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -437,7 +440,7 @@
             <h1
               class="mt-4 text-4xl md:text-5xl font-extrabold tracking-tight leading-tight"
             >
-              «Реверсивный инжиниринг и аддитивное производство»
+              R22.АТ.01 «Реверсивный инжиниринг и аддитивное производство»
             </h1>
             <p
               class="mt-4 text-lg text-slate-600 dark:text-slate-300 max-w-prose"
@@ -550,11 +553,7 @@
                 Переключайтесь, чтобы увидеть ключевые этапы практики.
               </p>
             </div>
-            <div
-              class="rounded-2xl border border-slate-200 bg-white/70 px-4 py-3 text-xs text-slate-500 shadow-sm backdrop-blur-sm dark:border-slate-700 dark:bg-slate-800/70 dark:text-slate-300"
-            >
-              Свайп или стрелки · 3 сцены
-            </div>
+            
           </div>
           <div class="mt-8">
             <div
@@ -759,6 +758,66 @@
               </ul>
             </article>
           </div>
+        </div>
+      </section>
+
+      <section id="tutorial" class="section-shell py-16 md:py-24">
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+            <div>
+              <h2 class="text-3xl md:text-4xl font-bold">Практический туториал</h2>
+              <p class="mt-3 max-w-2xl text-slate-600 dark:text-slate-300">
+                Пошаговый маршрут прохождения курса: от подготовки объекта и
+                сканирования до финальной печати и выдачи документации. Каждый
+                шаг сопровождается чек-листами и материалами из программы.
+              </p>
+            </div>
+            <div class="rounded-full border border-slate-200/80 bg-white/80 px-4 py-2 text-xs font-medium uppercase tracking-wide text-slate-500 shadow-sm backdrop-blur dark:border-slate-700/70 dark:bg-slate-800/70 dark:text-slate-300">
+              4 шага практики
+            </div>
+          </div>
+          <ol class="mt-8 grid gap-6 md:grid-cols-2">
+            <li class="surface-card-base flex gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm transition dark:border-slate-700 dark:bg-slate-800">
+              <span class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-slate-900 text-lg font-semibold text-white shadow-md dark:bg-white dark:text-slate-900">1</span>
+              <div class="space-y-2">
+                <h3 class="text-lg font-semibold">Подготовка объекта</h3>
+                <p class="text-sm text-slate-600 dark:text-slate-300">
+                  Анализ геометрии, выбор оснастки и маркировки, настройка
+                  шаблонов съёмки и техники безопасности.
+                </p>
+              </div>
+            </li>
+            <li class="surface-card-base flex gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm transition dark:border-slate-700 dark:bg-slate-800">
+              <span class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-slate-900 text-lg font-semibold text-white shadow-md dark:bg-white dark:text-slate-900">2</span>
+              <div class="space-y-2">
+                <h3 class="text-lg font-semibold">Сканирование и контроль</h3>
+                <p class="text-sm text-slate-600 dark:text-slate-300">
+                  Калибровка оборудования, захват облаков точек, фильтрация
+                  шумов и первичная проверка точности модели.
+                </p>
+              </div>
+            </li>
+            <li class="surface-card-base flex gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm transition dark:border-slate-700 dark:bg-slate-800">
+              <span class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-slate-900 text-lg font-semibold text-white shadow-md dark:bg-white dark:text-slate-900">3</span>
+              <div class="space-y-2">
+                <h3 class="text-lg font-semibold">Восстановление CAD-модели</h3>
+                <p class="text-sm text-slate-600 dark:text-slate-300">
+                  Построение NURBS-поверхностей, параметризация, выпуск
+                  конструкторской документации и контроль соответствия.
+                </p>
+              </div>
+            </li>
+            <li class="surface-card-base flex gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm transition dark:border-slate-700 dark:bg-slate-800">
+              <span class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-slate-900 text-lg font-semibold text-white shadow-md dark:bg-white dark:text-slate-900">4</span>
+              <div class="space-y-2">
+                <h3 class="text-lg font-semibold">Подготовка к печати</h3>
+                <p class="text-sm text-slate-600 dark:text-slate-300">
+                  Настройка печати в FDM/DLP/SLA, выбор материалов, подготовка
+                  поддержек и обработка готовых изделий.
+                </p>
+              </div>
+            </li>
+          </ol>
         </div>
       </section>
 
@@ -1438,49 +1497,18 @@
           <div
             class="rounded-3xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-soft"
           >
-            <h3 class="font-semibold mb-2">Адреса</h3>
-            <div
-              class="grid sm:grid-cols-2 gap-4 text-sm text-slate-700 dark:text-slate-300"
-            >
-              <div>
-                <div class="font-medium">ВДНХ</div>
-                <div>ул. Вильгельма Пика, 4, корп. 8</div>
-              </div>
-              <div>
-                <div class="font-medium">Беговая</div>
-                <div>ул. Беговая, 12</div>
-              </div>
+            <h3 class="font-semibold mb-2">Адрес</h3>
+            <div class="text-sm text-slate-700 dark:text-slate-300">
+              <div class="font-medium">Беговая</div>
+              <div>ул. Беговая, 12</div>
             </div>
             <div class="mt-6">
-              <div class="flex items-center gap-2 mb-3">
-                <button
-                  class="px-3 py-1.5 rounded-xl text-sm border bg-slate-900 text-white dark:bg-white dark:text-slate-900 border-slate-900 dark:border-white"
-                  data-maptab="0"
-                >
-                  ВДНХ
-                </button>
-                <button
-                  class="px-3 py-1.5 rounded-xl text-sm border bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700"
-                  data-maptab="1"
-                >
-                  Беговая
-                </button>
-              </div>
               <div
                 class="relative w-full overflow-hidden rounded-2xl border border-slate-200 dark:border-slate-700 aspect-video"
               >
                 <iframe
-                  title="Карта — ВДНХ"
-                  class="absolute inset-0 w-full h-full"
-                  data-map="0"
-                  src="https://www.google.com/maps?q=%D0%9C%D0%BE%D1%81%D0%BA%D0%B2%D0%B0,%20%D1%83%D0%BB.%20%D0%92%D0%B8%D0%BB%D1%8C%D0%B3%D0%B5%D0%BB%D1%8C%D0%BC%D0%B0%20%D0%9F%D0%B8%D0%BA%D0%B0,%204,%20%D0%BA%D0%BE%D1%80%D0%BF.%208&output=embed"
-                  loading="lazy"
-                  referrerpolicy="no-referrer-when-downgrade"
-                ></iframe>
-                <iframe
                   title="Карта — Беговая"
-                  class="absolute inset-0 w-full h-full opacity-0 pointer-events-none"
-                  data-map="1"
+                  class="absolute inset-0 w-full h-full"
                   src="https://www.google.com/maps?q=%D0%9C%D0%BE%D1%81%D0%BA%D0%B2%D0%B0,%20%D1%83%D0%BB.%20%D0%91%D0%B5%D0%B3%D0%BE%D0%B2%D0%B0%D1%8F,%2012&output=embed"
                   loading="lazy"
                   referrerpolicy="no-referrer-when-downgrade"
@@ -1699,7 +1727,7 @@
           <input
             type="hidden"
             name="course"
-            value="Реверсивный инжиниринг и аддитивное производство"
+            value="R22.АТ.01 «Реверсивный инжиниринг и аддитивное производство»"
           />
           <div
             class="hidden rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-800/70 dark:text-slate-200"
@@ -1749,7 +1777,7 @@
       const sectionMeta = {
         overview: {
           title:
-            "Step3D.Lab — Курс по реверсивному инжинирингу: программа и возможности",
+            "Step3D.Lab — Курс R22.АТ.01 по реверсивному инжинирингу: программа и возможности",
           description:
             "Обзор курса Step3D.Lab: цели обучения, индустриальные кейсы и компетенции по 3D-сканированию и аддитивному производству.",
         },
@@ -1769,7 +1797,7 @@
             "Модули курса Step3D.Lab: от 3D-сканирования и обработки сеток до CAD/CAM и постобработки.",
         },
         tutorial: {
-          title: "Step3D.Lab — Туториал и демо-материалы курса",
+          title: "Step3D.Lab — Практический туториал курса R22.АТ.01",
           description:
             "Погрузитесь в демо-материалы: видео, инструкции и шаблоны, которые получают слушатели курса Step3D.Lab.",
         },
@@ -2004,7 +2032,7 @@
             if (prefersReduceMotion?.matches) return;
             timerId = setInterval(
               () => setActive((+viewer.dataset.index || 0) + 1),
-              8000,
+              6500,
             );
           }
           prev?.addEventListener("click", () => {
@@ -2033,11 +2061,16 @@
               } else {
                 setActive((+viewer.dataset.index || 0) + 1);
               }
-              schedule();
+            } else {
+              setActive((+viewer.dataset.index || 0) + 1);
             }
+            schedule();
             startX = null;
           });
           viewer.addEventListener("pointerleave", () => {
+            startX = null;
+          });
+          viewer.addEventListener("pointercancel", () => {
             startX = null;
           });
           if (slides.length > 1) {
@@ -2061,7 +2094,7 @@
 
       initPhotoViewers();
 
-      // Переключение табов с картами (ВДНХ / Беговая)
+      // Переключение табов с картами (если присутствуют на странице)
       const mapTabs = document.querySelectorAll("[data-maptab]");
       if (mapTabs.length) {
         mapTabs.forEach((btn) =>


### PR DESCRIPTION
## Summary
- add course code R22.АТ.01 to the reverse engineering page metadata and hero heading, and tune the gallery autoplay for click navigation and faster rotation
- introduce a four-step “Практический туториал” section with redesigned numbered badges and update the contacts block to show only the Беговая location
- refresh the share action copy on the main page footer for a lighter, design-friendly label

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d43b8e04608333b9187423e286853c