### PR TITLE
Refine schedule and module card layout

### DIFF
--- a/assets/styles/components.css
+++ b/assets/styles/components.css
@@ -6,13 +6,61 @@
 .badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.35rem 0.65rem;
+  justify-content: center;
+  padding: 0.4rem 0.75rem;
   border-radius: 999px;
   font-size: 0.75rem;
   font-weight: 600;
-  background: rgba(255, 255, 255, 0.08);
-  color: var(--fg);
+  letter-spacing: 0.02em;
+  line-height: 1;
+  white-space: nowrap;
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--fg, #0f172a);
+}
+
+.badge--time {
+  background: rgba(148, 163, 184, 0.28);
+  color: var(--fg, #0f172a);
+}
+
+.badge--lecture {
+  background: rgba(16, 185, 129, 0.16);
+  color: #047857;
+}
+
+.badge--practice {
+  background: rgba(56, 189, 248, 0.18);
+  color: #0369a1;
+}
+
+.badge--control {
+  background: rgba(251, 191, 36, 0.22);
+  color: #b45309;
+}
+
+.dark .badge {
+  background: rgba(148, 163, 184, 0.22);
+  color: rgba(241, 245, 249, 0.88);
+}
+
+.dark .badge--time {
+  background: rgba(148, 163, 184, 0.32);
+  color: rgba(226, 232, 240, 0.92);
+}
+
+.dark .badge--lecture {
+  background: rgba(16, 185, 129, 0.22);
+  color: #34d399;
+}
+
+.dark .badge--practice {
+  background: rgba(56, 189, 248, 0.26);
+  color: #38bdf8;
+}
+
+.dark .badge--control {
+  background: rgba(251, 191, 36, 0.28);
+  color: #facc15;
 }
 
 .btn-icon {
@@ -561,4 +609,279 @@
   background: rgba(56, 189, 248, 0.24);
   color: rgb(125, 211, 252);
   box-shadow: 0 0 0 1px rgba(125, 211, 252, 0.2);
+}
+
+/* Module & tutorial cards */
+.card-surface {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: 1.5rem;
+  background: var(--card, rgba(255, 255, 255, 0.96));
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+}
+
+.dark .card-surface {
+  background: rgba(15, 23, 42, 0.82);
+  border-color: rgba(71, 85, 105, 0.6);
+  box-shadow: 0 24px 48px rgba(2, 6, 23, 0.55);
+}
+
+.card-surface h3 {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.card-surface p {
+  margin: 0;
+  color: rgba(71, 85, 105, 0.85);
+}
+
+.dark .card-surface p {
+  color: rgba(226, 232, 240, 0.86);
+}
+
+.card-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+  color: rgba(71, 85, 105, 0.9);
+}
+
+.dark .card-list {
+  color: rgba(203, 213, 225, 0.9);
+}
+
+.module-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 48rem) {
+  .module-grid {
+    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  }
+}
+
+.tutorial-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 48rem) {
+  .tutorial-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.tutorial-step {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.tutorial-step__index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 999px;
+  background: #0f172a;
+  color: #fff;
+  font-weight: 600;
+  font-size: 1.1rem;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.18);
+  flex: 0 0 auto;
+}
+
+.dark .tutorial-step__index {
+  background: #fff;
+  color: #0f172a;
+  box-shadow: 0 16px 36px rgba(2, 6, 23, 0.35);
+}
+
+.tutorial-step__body {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.tutorial-step__body p {
+  font-size: 0.95rem;
+  line-height: 1.65;
+}
+
+/* Schedule */
+.schedule-grid {
+  display: grid;
+  gap: 1.5rem;
+  width: min(100%, 50rem);
+  margin-inline: auto;
+}
+
+.schedule-item {
+  border-radius: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: var(--card, rgba(255, 255, 255, 0.96));
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+}
+
+.dark .schedule-item {
+  background: rgba(15, 23, 42, 0.82);
+  border-color: rgba(71, 85, 105, 0.6);
+  box-shadow: 0 24px 48px rgba(2, 6, 23, 0.55);
+}
+
+.schedule-card {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: flex-start;
+  padding: 1.5rem;
+  cursor: pointer;
+  list-style: none;
+  transition: background 0.2s ease;
+}
+
+.schedule-card::-webkit-details-marker {
+  display: none;
+}
+
+.schedule-card::marker {
+  content: '';
+}
+
+.schedule-card:hover,
+.schedule-item[open] .schedule-card {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.schedule-card__info {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.schedule-card__day {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(100, 116, 139, 0.85);
+}
+
+.dark .schedule-card__day {
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.schedule-card__title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  line-height: 1.45;
+  color: var(--fg, #0f172a);
+}
+
+.dark .schedule-card__title {
+  color: rgba(241, 245, 249, 0.95);
+}
+
+.schedule-card__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.75rem;
+  text-align: right;
+  min-width: 12rem;
+}
+
+.schedule-card__badges {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.schedule-card__content {
+  padding: 0 1.5rem 1.5rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.22);
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: rgba(71, 85, 105, 0.9);
+}
+
+.dark .schedule-card__content {
+  border-color: rgba(71, 85, 105, 0.55);
+  color: rgba(203, 213, 225, 0.9);
+}
+
+.schedule-card__list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.schedule-card__note {
+  color: rgba(100, 116, 139, 0.85);
+}
+
+.dark .schedule-card__note {
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.schedule-summary {
+  border-style: dashed;
+  border-color: rgba(148, 163, 184, 0.45);
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+}
+
+.schedule-summary h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.schedule-summary p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.65;
+}
+
+.dark .schedule-summary {
+  border-color: rgba(71, 85, 105, 0.55);
+  background: rgba(15, 23, 42, 0.78);
+  box-shadow: 0 18px 42px rgba(2, 6, 23, 0.45);
+}
+
+.schedule-summary__note {
+  color: rgba(100, 116, 139, 0.85);
+}
+
+.dark .schedule-summary__note {
+  color: rgba(148, 163, 184, 0.85);
+}
+
+@media (max-width: 47.99rem) {
+  .schedule-card {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1rem;
+  }
+
+  .schedule-card__meta {
+    align-items: flex-start;
+    text-align: left;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .schedule-card__badges {
+    justify-content: flex-start;
+  }
 }

--- a/reverse-additive.html
+++ b/reverse-additive.html
@@ -653,7 +653,6 @@
                 aria-hidden="true"
               ></div>
             </div>
-          </div>
         </div>
       </section>
 
@@ -712,14 +711,10 @@
           <h2 class="text-3xl md:text-4xl font-bold mb-6">
             Практические блоки
           </h2>
-          <div class="grid lg:grid-cols-3 gap-6 md:gap-8">
-            <article
-              class="surface-card-base rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800"
-            >
-              <h3 class="text-lg font-semibold">3D‑сканирование</h3>
-              <ul
-                class="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc pl-5"
-              >
+          <div class="module-grid">
+            <article class="card-surface">
+              <h3>3D‑сканирование</h3>
+              <ul class="card-list">
                 <li>Выбор метода оцифровки и оснастки.</li>
                 <li>
                   Калибровка и захват данных на стационарных и ручных сканерах.
@@ -727,13 +722,9 @@
                 <li>Контроль качества облаков точек.</li>
               </ul>
             </article>
-            <article
-              class="surface-card-base rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800"
-            >
-              <h3 class="text-lg font-semibold">Реверсивный инжиниринг</h3>
-              <ul
-                class="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc pl-5"
-              >
+            <article class="card-surface">
+              <h3>Реверсивный инжиниринг</h3>
+              <ul class="card-list">
                 <li>
                   Работа в Geomagic Design X (базовые и продвинутые функции).
                 </li>
@@ -741,13 +732,9 @@
                 <li>Подготовка конструкторской документации.</li>
               </ul>
             </article>
-            <article
-              class="surface-card-base rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800"
-            >
-              <h3 class="text-lg font-semibold">Аддитивное производство</h3>
-              <ul
-                class="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc pl-5"
-              >
+            <article class="card-surface">
+              <h3>Аддитивное производство</h3>
+              <ul class="card-list">
                 <li>Подготовка моделей к 3D‑печати (FDM/DLP/SLA).</li>
                 <li>
                   Изготовление мастер‑моделей и производственной оснастки.
@@ -776,42 +763,42 @@
               4 шага практики
             </div>
           </div>
-          <ol class="mt-8 grid gap-6 md:grid-cols-2">
-            <li class="surface-card-base flex gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm transition dark:border-slate-700 dark:bg-slate-800">
-              <span class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-slate-900 text-lg font-semibold text-white shadow-md dark:bg-white dark:text-slate-900">1</span>
-              <div class="space-y-2">
-                <h3 class="text-lg font-semibold">Подготовка объекта</h3>
-                <p class="text-sm text-slate-600 dark:text-slate-300">
+          <ol class="tutorial-grid mt-8">
+            <li class="card-surface tutorial-step">
+              <span class="tutorial-step__index">1</span>
+              <div class="tutorial-step__body">
+                <h3>Подготовка объекта</h3>
+                <p>
                   Анализ геометрии, выбор оснастки и маркировки, настройка
                   шаблонов съёмки и техники безопасности.
                 </p>
               </div>
             </li>
-            <li class="surface-card-base flex gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm transition dark:border-slate-700 dark:bg-slate-800">
-              <span class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-slate-900 text-lg font-semibold text-white shadow-md dark:bg-white dark:text-slate-900">2</span>
-              <div class="space-y-2">
-                <h3 class="text-lg font-semibold">Сканирование и контроль</h3>
-                <p class="text-sm text-slate-600 dark:text-slate-300">
+            <li class="card-surface tutorial-step">
+              <span class="tutorial-step__index">2</span>
+              <div class="tutorial-step__body">
+                <h3>Сканирование и контроль</h3>
+                <p>
                   Калибровка оборудования, захват облаков точек, фильтрация
                   шумов и первичная проверка точности модели.
                 </p>
               </div>
             </li>
-            <li class="surface-card-base flex gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm transition dark:border-slate-700 dark:bg-slate-800">
-              <span class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-slate-900 text-lg font-semibold text-white shadow-md dark:bg-white dark:text-slate-900">3</span>
-              <div class="space-y-2">
-                <h3 class="text-lg font-semibold">Восстановление CAD-модели</h3>
-                <p class="text-sm text-slate-600 dark:text-slate-300">
+            <li class="card-surface tutorial-step">
+              <span class="tutorial-step__index">3</span>
+              <div class="tutorial-step__body">
+                <h3>Восстановление CAD-модели</h3>
+                <p>
                   Построение NURBS-поверхностей, параметризация, выпуск
                   конструкторской документации и контроль соответствия.
                 </p>
               </div>
             </li>
-            <li class="surface-card-base flex gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm transition dark:border-slate-700 dark:bg-slate-800">
-              <span class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-slate-900 text-lg font-semibold text-white shadow-md dark:bg-white dark:text-slate-900">4</span>
-              <div class="space-y-2">
-                <h3 class="text-lg font-semibold">Подготовка к печати</h3>
-                <p class="text-sm text-slate-600 dark:text-slate-300">
+            <li class="card-surface tutorial-step">
+              <span class="tutorial-step__index">4</span>
+              <div class="tutorial-step__body">
+                <h3>Подготовка к печати</h3>
+                <p>
                   Настройка печати в FDM/DLP/SLA, выбор материалов, подготовка
                   поддержек и обработка готовых изделий.
                 </p>
@@ -831,48 +818,27 @@
             академических часов. Каждому модулю соответствует практическая
             работа или мастер-класс с итоговым контролем.
           </p>
-          <div class="space-y-4">
-            <details
-              class="surface-card-base group rounded-3xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/40"
-            >
-              <summary
-                class="flex cursor-pointer flex-col gap-3 rounded-3xl px-5 py-4 transition-colors group-open:bg-slate-50/80 dark:group-open:bg-slate-800/40 sm:flex-row sm:items-center sm:justify-between"
-              >
-                <div>
-                  <span
-                    class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400"
-                    >01 · Понедельник</span
-                  >
-                  <h3 class="text-lg font-semibold">
+          <div class="schedule-grid">
+            <details class="schedule-item">
+              <summary class="schedule-card">
+                <div class="schedule-card__info">
+                  <span class="schedule-card__day">01 · Понедельник</span>
+                  <h3 class="schedule-card__title">
                     Старт, техника безопасности и введение в реверсивный
                     инжиниринг
                   </h3>
                 </div>
-                <div
-                  class="flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-slate-300"
-                >
-                  <span
-                    class="rounded-full bg-slate-100 px-3 py-1 dark:bg-slate-800"
-                    >10 ч</span
-                  >
-                  <span
-                    class="rounded-full bg-emerald-100 px-3 py-1 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200"
-                    >Лекции 1 ч</span
-                  >
-                  <span
-                    class="rounded-full bg-sky-100 px-3 py-1 text-sky-700 dark:bg-sky-500/20 dark:text-sky-200"
-                    >Практика 8,5 ч</span
-                  >
-                  <span
-                    class="rounded-full bg-amber-100 px-3 py-1 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200"
-                    >Контроль 0,5 ч</span
-                  >
+                <div class="schedule-card__meta">
+                  <span class="badge badge--time">10 ч</span>
+                  <div class="schedule-card__badges">
+                    <span class="badge badge--lecture">Лекции 1 ч</span>
+                    <span class="badge badge--practice">Практика 8,5 ч</span>
+                    <span class="badge badge--control">Контроль 0,5 ч</span>
+                  </div>
                 </div>
               </summary>
-              <div
-                class="border-t border-slate-100 px-5 py-5 text-sm leading-relaxed dark:border-slate-800"
-              >
-                <ul class="space-y-3">
+              <div class="schedule-card__content">
+                <ul class="schedule-card__list">
                   <li>
                     <strong>Лекция.</strong> Реверсивный инжиниринг и технологии
                     аддитивного производства. Опыт РГСУ и кейсы чемпионатов
@@ -891,52 +857,31 @@
                     <strong>Практика №2.</strong> 3D-сканирование на
                     стационарном сканере (RangeVision Spectrum).
                   </li>
-                  <li class="text-slate-500 dark:text-slate-400">
+                  <li class="schedule-card__note">
                     Форма контроля: устный опрос, зачёт.
                   </li>
                 </ul>
               </div>
             </details>
-            <details
-              class="surface-card-base group rounded-3xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/40"
-            >
-              <summary
-                class="flex cursor-pointer flex-col gap-3 rounded-3xl px-5 py-4 transition-colors group-open:bg-slate-50/80 dark:group-open:bg-slate-800/40 sm:flex-row sm:items-center sm:justify-between"
-              >
-                <div>
-                  <span
-                    class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400"
-                    >02 · Вторник</span
-                  >
-                  <h3 class="text-lg font-semibold">
+            <details class="schedule-item">
+              <summary class="schedule-card">
+                <div class="schedule-card__info">
+                  <span class="schedule-card__day">02 · Вторник</span>
+                  <h3 class="schedule-card__title">
                     Практика в Geomagic и основы 3D-печати
                   </h3>
                 </div>
-                <div
-                  class="flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-slate-300"
-                >
-                  <span
-                    class="rounded-full bg-slate-100 px-3 py-1 dark:bg-slate-800"
-                    >8 ч</span
-                  >
-                  <span
-                    class="rounded-full bg-emerald-100 px-3 py-1 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200"
-                    >Лекции 0,5 ч</span
-                  >
-                  <span
-                    class="rounded-full bg-sky-100 px-3 py-1 text-sky-700 dark:bg-sky-500/20 dark:text-sky-200"
-                    >Практика 6 ч</span
-                  >
-                  <span
-                    class="rounded-full bg-amber-100 px-3 py-1 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200"
-                    >Контроль 1,5 ч</span
-                  >
+                <div class="schedule-card__meta">
+                  <span class="badge badge--time">8 ч</span>
+                  <div class="schedule-card__badges">
+                    <span class="badge badge--lecture">Лекции 0,5 ч</span>
+                    <span class="badge badge--practice">Практика 6 ч</span>
+                    <span class="badge badge--control">Контроль 1,5 ч</span>
+                  </div>
                 </div>
               </summary>
-              <div
-                class="border-t border-slate-100 px-5 py-5 text-sm leading-relaxed dark:border-slate-800"
-              >
-                <ul class="space-y-3">
+              <div class="schedule-card__content">
+                <ul class="schedule-card__list">
                   <li>
                     <strong>Практика №3.</strong> Реверсивный инжиниринг в
                     Geomagic Design X (базовые функции).
@@ -949,52 +894,29 @@
                     <strong>Практика №4.</strong> Подготовка моделей к 3D-печати
                     по технологиям FDM/DLP/SLA. Запуск печати.
                   </li>
-                  <li class="text-slate-500 dark:text-slate-400">
-                    Форма контроля: зачёт.
-                  </li>
+                  <li class="schedule-card__note">Форма контроля: зачёт.</li>
                 </ul>
               </div>
             </details>
-            <details
-              class="surface-card-base group rounded-3xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/40"
-            >
-              <summary
-                class="flex cursor-pointer flex-col gap-3 rounded-3xl px-5 py-4 transition-colors group-open:bg-slate-50/80 dark:group-open:bg-slate-800/40 sm:flex-row sm:items-center sm:justify-between"
-              >
-                <div>
-                  <span
-                    class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400"
-                    >03 · Среда</span
-                  >
-                  <h3 class="text-lg font-semibold">
+            <details class="schedule-item">
+              <summary class="schedule-card">
+                <div class="schedule-card__info">
+                  <span class="schedule-card__day">03 · Среда</span>
+                  <h3 class="schedule-card__title">
                     Ручное 3D-сканирование и продвинутые инструменты
                   </h3>
                 </div>
-                <div
-                  class="flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-slate-300"
-                >
-                  <span
-                    class="rounded-full bg-slate-100 px-3 py-1 dark:bg-slate-800"
-                    >8 ч</span
-                  >
-                  <span
-                    class="rounded-full bg-emerald-100 px-3 py-1 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200"
-                    >Лекции 1,5 ч</span
-                  >
-                  <span
-                    class="rounded-full bg-sky-100 px-3 py-1 text-sky-700 dark:bg-sky-500/20 dark:text-sky-200"
-                    >Практика 6 ч</span
-                  >
-                  <span
-                    class="rounded-full bg-amber-100 px-3 py-1 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200"
-                    >Контроль 0,5 ч</span
-                  >
+                <div class="schedule-card__meta">
+                  <span class="badge badge--time">8 ч</span>
+                  <div class="schedule-card__badges">
+                    <span class="badge badge--lecture">Лекции 1,5 ч</span>
+                    <span class="badge badge--practice">Практика 6 ч</span>
+                    <span class="badge badge--control">Контроль 0,5 ч</span>
+                  </div>
                 </div>
               </summary>
-              <div
-                class="border-t border-slate-100 px-5 py-5 text-sm leading-relaxed dark:border-slate-800"
-              >
-                <ul class="space-y-3">
+              <div class="schedule-card__content">
+                <ul class="schedule-card__list">
                   <li>
                     <strong>Мастер-класс №3.</strong> 3D-сканирование ручным
                     оптическим сканером (Artec Eva).
@@ -1003,52 +925,31 @@
                     <strong>Практика №5.</strong> Реверсивный инжиниринг в
                     Geomagic Design X (продвинутые функции).
                   </li>
-                  <li class="text-slate-500 dark:text-slate-400">
+                  <li class="schedule-card__note">
                     Форма контроля: устный опрос, зачёт.
                   </li>
                 </ul>
               </div>
             </details>
-            <details
-              class="surface-card-base group rounded-3xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/40"
-            >
-              <summary
-                class="flex cursor-pointer flex-col gap-3 rounded-3xl px-5 py-4 transition-colors group-open:bg-slate-50/80 dark:group-open:bg-slate-800/40 sm:flex-row sm:items-center sm:justify-between"
-              >
-                <div>
-                  <span
-                    class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400"
-                    >04 · Четверг</span
-                  >
-                  <h3 class="text-lg font-semibold">
+            <details class="schedule-item">
+              <summary class="schedule-card">
+                <div class="schedule-card__info">
+                  <span class="schedule-card__day">04 · Четверг</span>
+                  <h3 class="schedule-card__title">
                     Продвинутые технологии печати и свободный практикум
                   </h3>
                 </div>
-                <div
-                  class="flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-slate-300"
-                >
-                  <span
-                    class="rounded-full bg-slate-100 px-3 py-1 dark:bg-slate-800"
-                    >8 ч</span
-                  >
-                  <span
-                    class="rounded-full bg-emerald-100 px-3 py-1 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200"
-                    >Лекции 1 ч</span
-                  >
-                  <span
-                    class="rounded-full bg-sky-100 px-3 py-1 text-sky-700 dark:bg-sky-500/20 dark:text-sky-200"
-                    >Практика 6,5 ч</span
-                  >
-                  <span
-                    class="rounded-full bg-amber-100 px-3 py-1 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200"
-                    >Контроль 0,5 ч</span
-                  >
+                <div class="schedule-card__meta">
+                  <span class="badge badge--time">8 ч</span>
+                  <div class="schedule-card__badges">
+                    <span class="badge badge--lecture">Лекции 1 ч</span>
+                    <span class="badge badge--practice">Практика 6,5 ч</span>
+                    <span class="badge badge--control">Контроль 0,5 ч</span>
+                  </div>
                 </div>
               </summary>
-              <div
-                class="border-t border-slate-100 px-5 py-5 text-sm leading-relaxed dark:border-slate-800"
-              >
-                <ul class="space-y-3">
+              <div class="schedule-card__content">
+                <ul class="schedule-card__list">
                   <li>
                     <strong>Мастер-класс №4.</strong> Основы 3D-печати по
                     технологиям DLP/SLA (индустриальный партнёр).
@@ -1061,118 +962,74 @@
                     <strong>Свободный практикум.</strong> Отработка навыков
                     3D-сканирования, реверсивного инжиниринга и 3D-печати.
                   </li>
-                  <li class="text-slate-500 dark:text-slate-400">
+                  <li class="schedule-card__note">
                     Форма контроля: устный опрос, зачёт.
                   </li>
                 </ul>
               </div>
             </details>
-            <details
-              class="surface-card-base group rounded-3xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/40"
-            >
-              <summary
-                class="flex cursor-pointer flex-col gap-3 rounded-3xl px-5 py-4 transition-colors group-open:bg-slate-50/80 dark:group-open:bg-slate-800/40 sm:flex-row sm:items-center sm:justify-between"
-              >
-                <div>
-                  <span
-                    class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400"
-                    >05 · Пятница</span
-                  >
-                  <h3 class="text-lg font-semibold">
+            <details class="schedule-item">
+              <summary class="schedule-card">
+                <div class="schedule-card__info">
+                  <span class="schedule-card__day">05 · Пятница</span>
+                  <h3 class="schedule-card__title">
                     Чемпионатный день и демонстрационный экзамен
                   </h3>
                 </div>
-                <div
-                  class="flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-slate-300"
-                >
-                  <span
-                    class="rounded-full bg-slate-100 px-3 py-1 dark:bg-slate-800"
-                    >16 ч</span
-                  >
-                  <span
-                    class="rounded-full bg-emerald-100 px-3 py-1 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200"
-                    >Лекции 2 ч</span
-                  >
-                  <span
-                    class="rounded-full bg-sky-100 px-3 py-1 text-sky-700 dark:bg-sky-500/20 dark:text-sky-200"
-                    >Практика 12 ч</span
-                  >
-                  <span
-                    class="rounded-full bg-amber-100 px-3 py-1 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200"
-                    >Контроль 2 ч</span
-                  >
+                <div class="schedule-card__meta">
+                  <span class="badge badge--time">16 ч</span>
+                  <div class="schedule-card__badges">
+                    <span class="badge badge--lecture">Лекции 2 ч</span>
+                    <span class="badge badge--practice">Практика 12 ч</span>
+                    <span class="badge badge--control">Контроль 2 ч</span>
+                  </div>
                 </div>
               </summary>
-              <div
-                class="border-t border-slate-100 px-5 py-5 text-sm leading-relaxed dark:border-slate-800"
-              >
-                <ul class="space-y-3">
+              <div class="schedule-card__content">
+                <ul class="schedule-card__list">
                   <li>
                     <strong>Чемпионатное задание.</strong> Выполнение задания
                     формата International High-Tech Competition 2023 по
                     компетенции «Реверсивный инжиниринг».
                   </li>
-                  <li class="text-slate-500 dark:text-slate-400">
+                  <li class="schedule-card__note">
                     Форма контроля: демонстрационный экзамен.
                   </li>
                 </ul>
               </div>
             </details>
-            <details
-              class="surface-card-base group rounded-3xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/40"
-            >
-              <summary
-                class="flex cursor-pointer flex-col gap-3 rounded-3xl px-5 py-4 transition-colors group-open:bg-slate-50/80 dark:group-open:bg-slate-800/40 sm:flex-row sm:items-center sm:justify-between"
-              >
-                <div>
-                  <span
-                    class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400"
-                    >06 · Суббота</span
-                  >
-                  <h3 class="text-lg font-semibold">
+            <details class="schedule-item">
+              <summary class="schedule-card">
+                <div class="schedule-card__info">
+                  <span class="schedule-card__day">06 · Суббота</span>
+                  <h3 class="schedule-card__title">
                     Резервный день и консультации
                   </h3>
                 </div>
-                <div
-                  class="flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-slate-300"
-                >
-                  <span
-                    class="rounded-full bg-slate-100 px-3 py-1 dark:bg-slate-800"
-                    >—</span
-                  >
-                  <span
-                    class="rounded-full bg-emerald-100 px-3 py-1 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200"
-                    >Лекции —</span
-                  >
-                  <span
-                    class="rounded-full bg-sky-100 px-3 py-1 text-sky-700 dark:bg-sky-500/20 dark:text-sky-200"
-                    >Практика —</span
-                  >
-                  <span
-                    class="rounded-full bg-amber-100 px-3 py-1 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200"
-                    >Контроль —</span
-                  >
+                <div class="schedule-card__meta">
+                  <span class="badge badge--time">—</span>
+                  <div class="schedule-card__badges">
+                    <span class="badge badge--lecture">Лекции —</span>
+                    <span class="badge badge--practice">Практика —</span>
+                    <span class="badge badge--control">Контроль —</span>
+                  </div>
                 </div>
               </summary>
-              <div
-                class="border-t border-slate-100 px-5 py-5 text-sm leading-relaxed dark:border-slate-800"
-              >
-                <p>Резервный день и консультации по индивидуальным проектам.</p>
+              <div class="schedule-card__content">
+                <p>
+                  Резервный день и консультации по индивидуальным проектам.
+                </p>
               </div>
             </details>
-            <div
-              class="surface-card-base rounded-3xl border border-dashed border-slate-300 bg-white/60 p-6 text-sm leading-relaxed shadow-sm dark:border-slate-700 dark:bg-slate-900/20"
-            >
-              <h3 class="text-base font-semibold">Итог по программе</h3>
-              <p class="mt-2 text-slate-600 dark:text-slate-300">
+            <div class="card-surface schedule-summary">
+              <h3>Итог по программе</h3>
+              <p>
                 6 модулей, 4 мастер-класса, 6 практических работ и
                 демонстрационный экзамен. Общий объём —
                 <strong>48 академических часов</strong>, из них 6 часов лекций,
                 32 часа практики и 10 часов контроля.
               </p>
-              <p class="mt-3 text-slate-500 dark:text-slate-400">
-                Форма итогового контроля — зачёт.
-              </p>
+              <p class="schedule-summary__note">Форма итогового контроля — зачёт.</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- standardize badge styling and add shared card/schedule helpers for consistent module, tutorial, and timetable layouts
- rebuild module, tutorial, and schedule markup to align headings, badges, and spacing on an even grid with responsive behaviour

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d44617aee88333b5dab30796ccc9a7