### PR TITLE
Switch navbar logo to SVG asset

### DIFF
--- a/assets/styles/site.css
+++ b/assets/styles/site.css
@@ -57,6 +57,19 @@
   }
 }
 
+.top-nav__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: inherit;
+}
+
+.top-nav__logo {
+  height: clamp(32px, 4vw, 48px);
+  width: auto;
+  flex-shrink: 0;
+}
+
 .top-nav__links {
   display: flex;
   align-items: center;

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
         <nav class="top-nav" aria-label="Главная навигация">
           <a href="#top" class="top-nav__brand">
             <img
-              src="Logo_Step_3D.jpg"
+              src="Logo.svg"
               alt="Логотип Step3D.Lab"
               class="top-nav__logo"
               loading="eager"


### PR DESCRIPTION
## Summary
- swap the navigation logo image to the optimized Logo.svg asset
- add sizing styles so the brand lockup keeps a balanced visual weight

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d44ab1f1c08333928cea779a97d929