### PR TITLE
Replace training link text with logo image

### DIFF
--- a/index.html
+++ b/index.html
@@ -1892,7 +1892,13 @@
                   rel="noopener noreferrer"
                   class="mt-2 inline-flex items-center gap-2 rounded-xl bg-slate-100 px-3 py-1.5 font-medium text-slate-900 transition hover:bg-slate-200 focus:outline-none focus:ring-4 focus:ring-slate-200 dark:bg-slate-700/70 dark:text-slate-100 dark:hover:bg-slate-600"
                 >
-                  technopark-rgsu.ru
+                  <img
+                    src="https://optim.tildacdn.com/tild3331-6338-4339-b266-663436633930/-/resize/224x/-/format/webp/LOGO.png.webp"
+                    alt="Технопарк РГСУ"
+                    class="h-8 w-auto"
+                    loading="lazy"
+                    decoding="async"
+                  />
                 </a>
                 <div class="mt-2 text-xs text-slate-600 dark:text-slate-200">
                   Образовательные программы и профориентация школьников.


### PR DESCRIPTION
## Summary
- replace the training and career guidance link text with the technopark logo image

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d44b1f70388333a8f4d556822b9d91