### PR TITLE
feat: update CTA styling and unify footer layout

### DIFF
--- a/assets/styles/base.css
+++ b/assets/styles/base.css
@@ -182,6 +182,8 @@ a:hover {
   font-weight: 600;
   text-decoration: none;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  position: relative;
+  overflow: hidden;
 }
 
 .btn:hover {
@@ -193,6 +195,87 @@ a:hover {
 .btn-primary {
   background: linear-gradient(180deg, rgba(110, 168, 254, 0.18), rgba(110, 168, 254, 0.06));
   border-color: rgba(110, 168, 254, 0.35);
+}
+
+.btn-cta {
+  color: #fff;
+  background: linear-gradient(120deg, #38bdf8, #6366f1, #ec4899);
+  border-color: rgba(99, 102, 241, 0.45);
+  box-shadow: 0 18px 38px rgba(99, 102, 241, 0.35);
+  background-size: 200% 200%;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.btn-cta::after {
+  content: "";
+  position: absolute;
+  inset: -50% -20% 60% -20%;
+  background: radial-gradient(80% 120% at 50% 0%, rgba(255, 255, 255, 0.65), transparent 70%);
+  opacity: 0;
+  transform: translateY(20%);
+  transition: opacity 0.35s ease, transform 0.35s ease;
+  pointer-events: none;
+}
+
+.btn-cta:hover,
+.btn-cta:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 46px rgba(99, 102, 241, 0.45);
+}
+
+.btn-cta:hover::after,
+.btn-cta:focus-visible::after {
+  opacity: 0.75;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .btn-cta {
+    animation: ctaGradientShift 5.5s ease infinite;
+  }
+
+  .btn-cta::before {
+    content: "";
+    position: absolute;
+    inset: -1px;
+    background: linear-gradient(120deg, rgba(255, 255, 255, 0.45), transparent 35%, rgba(255, 255, 255, 0.35));
+    opacity: 0;
+    transform: translateX(-60%);
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+    mix-blend-mode: screen;
+  }
+
+  .btn-cta:hover::before,
+  .btn-cta:focus-visible::before {
+    opacity: 0.6;
+    animation: ctaShimmer 1.4s ease;
+  }
+}
+
+@keyframes ctaGradientShift {
+  0%,
+  100% {
+    background-position: 0% 50%;
+  }
+
+  50% {
+    background-position: 100% 50%;
+  }
+}
+
+@keyframes ctaShimmer {
+  0% {
+    transform: translateX(-65%) rotate(12deg);
+  }
+
+  50% {
+    transform: translateX(65%) rotate(12deg);
+  }
+
+  100% {
+    transform: translateX(85%) rotate(12deg);
+  }
 }
 
 

--- a/assets/styles/site.css
+++ b/assets/styles/site.css
@@ -72,8 +72,23 @@
   border-radius: 999px;
   font-weight: 600;
   color: rgb(71, 85, 105);
-  transition: color 0.2s ease, background-color 0.2s ease,
-    box-shadow 0.2s ease;
+  position: relative;
+  transition: color 0.2s ease;
+}
+
+.top-nav__link::after {
+  content: "";
+  position: absolute;
+  left: 0.7rem;
+  right: 0.7rem;
+  bottom: 0.2rem;
+  height: 3px;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0;
+  transform: scaleX(0.5);
+  transform-origin: center;
+  transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
 .top-nav__link:hover,
@@ -83,9 +98,15 @@
 
 .top-nav__link.active-link,
 .top-nav__link[aria-current="page"] {
-  background: rgb(15, 23, 42);
-  color: #fff;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.15);
+  color: rgb(15, 23, 42);
+  background: transparent;
+  box-shadow: none;
+}
+
+.top-nav__link.active-link::after,
+.top-nav__link[aria-current="page"]::after {
+  opacity: 1;
+  transform: scaleX(1);
 }
 
 .dark .top-nav__link {
@@ -99,9 +120,9 @@
 
 .dark .top-nav__link.active-link,
 .dark .top-nav__link[aria-current="page"] {
-  background: rgb(226, 232, 240);
-  color: rgb(15, 23, 42);
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.28);
+  color: rgb(226, 232, 240);
+  background: transparent;
+  box-shadow: none;
 }
 
 .top-nav__mobile-links {

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
               «СТЕП 3Д».
             </p>
             <div class="hero__actions">
-              <button id="openModal" class="btn btn-primary">Оставить заявку</button>
+              <button id="openModal" class="btn btn-primary btn-cta">Оставить заявку</button>
               <button
                 id="toggleAbout"
                 class="btn btn-outline"
@@ -1820,7 +1820,7 @@
       class="section-shell py-16 md:py-24 border-t border-slate-200/60 dark:border-slate-700/60"
     >
 
-              <button id="openModal2" class="btn btn-primary">
+              <button id="openModal2" class="btn btn-primary btn-cta">
                 Оставить заявку
               </button>
               <a
@@ -2253,7 +2253,7 @@
     <div
       id="nav-data"
       class="hidden"
-      data-nav='[{"id":"top","label":"Главная"},{"id":"equipment","label":"Оборудование"},{"id":"projects","label":"Проекты"},{"id":"courses","label":"Обучение"},{"id":"team","label":"Команда"},{"id":"blog","label":"Новости"},{"id":"faq","label":"Часто задаваемые вопросы"},{"id":"contacts","label":"Контакты"}]'
+      data-nav='[{"id":"top","label":"Главная"},{"id":"courses","label":"ДПО R22 и A"}]'
     ></div>
 
 

--- a/reverse-additive.html
+++ b/reverse-additive.html
@@ -277,39 +277,6 @@
         }
       }
 
-      .primary-button {
-        position: relative;
-        overflow: hidden;
-        isolation: isolate;
-        transition: transform 0.35s ease, box-shadow 0.35s ease;
-      }
-
-      .primary-button::after {
-        content: "";
-        position: absolute;
-        inset: -40% -20% 60% -20%;
-        background: radial-gradient(
-          90% 120% at 50% 0%,
-          rgba(255, 255, 255, 0.6),
-          transparent
-        );
-        opacity: 0;
-        transition: opacity 0.35s ease, transform 0.35s ease;
-        z-index: -1;
-      }
-
-      .primary-button:hover,
-      .primary-button:focus-visible {
-        transform: translateY(-2px);
-        box-shadow: 0 20px 45px -22px rgba(15, 23, 42, 0.45);
-      }
-
-      .primary-button:hover::after,
-      .primary-button:focus-visible::after {
-        opacity: 1;
-        transform: translateY(-6%);
-      }
-
       .secondary-button {
         transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease;
       }
@@ -326,13 +293,8 @@
         .floating-nav-shell,
         .floating-nav-menu,
         .surface-card-base,
-        .primary-button,
         .secondary-button {
           transition-duration: 0s;
-        }
-
-        .primary-button::after {
-          display: none;
         }
       }
 
@@ -454,7 +416,7 @@
             <div class="mt-6 flex flex-wrap gap-3">
               <button
                 id="openModal"
-                class="primary-button inline-flex items-center gap-2 rounded-xl bg-slate-900 px-5 py-3 text-white font-medium shadow hover:bg-slate-800 focus:outline-none focus:ring-4 focus:ring-slate-300"
+                class="btn btn-primary btn-cta inline-flex items-center gap-2 rounded-xl px-5 py-3 text-base font-semibold focus:outline-none focus:ring-4 focus:ring-slate-300/40"
               >
                 Оставить заявку
               </button>
@@ -1424,39 +1386,56 @@
     </main>
 
     <footer
+      id="contacts"
+      class="section-shell py-16 md:py-24 border-t border-slate-200/60 dark:border-slate-700/60"
+    >
 
-                >
+              <button id="openModal2" class="btn btn-primary btn-cta">
+                Оставить заявку
+              </button>
+              <a
+                href="https://t.me/step_3d_mngr"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="btn btn-outline"
+                >Написать нам в телеграм</a
+              >
+              <button id="shareLink" type="button" class="btn btn-outline">
+                Поделиться ↗
+              </button>
+            </div>
+
                   По всем вопросам
                 </div>
-                <a
-
+                <a href="mailto:projects.step3d@gmail.com" class="btn btn-primary mt-2">
+                  projects.step3d@gmail.com
+                </a>
+                <div class="mt-2 text-xs text-slate-600 dark:text-slate-200">
+                  Почта команды Step3D.Lab для любых запросов и заявок.
+                </div>
               </div>
               <div
                 class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800"
               >
-                <div
-                  class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
-                >
 
+                  Контакт в Telegram
                 </div>
                 <a
                   href="https://t.me/step_3d_mngr"
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="mt-2 inline-flex items-center gap-2 rounded-xl bg-slate-100 px-3 py-1.5 font-mono text-base text-slate-900 transition hover:bg-slate-200 focus:outline-none focus:ring-4 focus:ring-slate-200 dark:bg-slate-700/70 dark:text-slate-100 dark:hover:bg-slate-600"
+                  class="btn btn-outline contact-handle mt-2"
                 >
                   @step_3d_mngr
                 </a>
-                <div class="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                <div class="mt-2 text-xs text-slate-600 dark:text-slate-200">
                   Никита — менеджер проекта, оперативная связь по Telegram.
                 </div>
               </div>
               <div
                 class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800"
               >
-                <div
-                  class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
-                >
+
                   Портфолио и новости
                 </div>
                 <a
@@ -1467,17 +1446,14 @@
                 >
                   t.me/STEP_3D_Lab
                 </a>
-                <div class="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                <div class="mt-2 text-xs text-slate-600 dark:text-slate-200">
                   Кейсы лаборатории, новости проектов и behind the scenes.
                 </div>
               </div>
-
               <div
                 class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-800"
               >
-                <div
-                  class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
-                >
+
                   Обучение и профориентация
                 </div>
                 <a
@@ -1488,34 +1464,131 @@
                 >
                   technopark-rgsu.ru
                 </a>
-                <div class="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                <div class="mt-2 text-xs text-slate-600 dark:text-slate-200">
                   Образовательные программы и профориентация школьников.
                 </div>
               </div>
             </div>
           </div>
-          <div
-            class="rounded-3xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-soft"
-          >
-            <h3 class="font-semibold mb-2">Адрес</h3>
-            <div class="text-sm text-slate-700 dark:text-slate-300">
-              <div class="font-medium">Беговая</div>
-              <div>ул. Беговая, 12</div>
-            </div>
-            <div class="mt-6">
-              <div
-                class="relative w-full overflow-hidden rounded-2xl border border-slate-200 dark:border-slate-700 aspect-video"
-              >
-                <iframe
-                  title="Карта — Беговая"
-                  class="absolute inset-0 w-full h-full"
-                  src="https://www.google.com/maps?q=%D0%9C%D0%BE%D1%81%D0%BA%D0%B2%D0%B0,%20%D1%83%D0%BB.%20%D0%91%D0%B5%D0%B3%D0%BE%D0%B2%D0%B0%D1%8F,%2012&output=embed"
-                  loading="lazy"
-                  referrerpolicy="no-referrer-when-downgrade"
-                ></iframe>
+
+                >
+                  <button
+                    class="px-3 py-1.5 rounded-xl text-sm font-medium text-white bg-slate-900 dark:bg-white dark:text-slate-900 shadow-sm"
+                    data-maptab="0"
+                    data-active-class="bg-slate-900 text-white dark:bg-white dark:text-slate-900"
+                    data-inactive-class="text-slate-700 dark:text-slate-200"
+                  >
+                    ВДНХ
+                  </button>
+                  <button
+                    class="px-3 py-1.5 rounded-xl text-sm font-medium text-slate-700 dark:text-slate-200 shadow-sm"
+                    data-maptab="1"
+                    data-active-class="bg-slate-900 text-white dark:bg-white dark:text-slate-900"
+                    data-inactive-class="text-slate-700 dark:text-slate-200"
+                  >
+                    Беговая
+                  </button>
+                </div>
               </div>
             </div>
-            <div class="mt-4 text-sm text-slate-500 dark:text-slate-400">
+            <div class="grid gap-4 sm:grid-cols-2 text-sm text-slate-700 dark:text-slate-200">
+              <div class="rounded-2xl bg-white/70 dark:bg-slate-800/70 border border-slate-200 dark:border-slate-700 p-4 shadow-sm">
+                <div class="flex items-start justify-between gap-3">
+                  <div>
+                    <div class="font-semibold text-slate-900 dark:text-white">
+                      ВДНХ
+                    </div>
+                    <div>ул. Вильгельма Пика, 4, корп. 8</div>
+                  </div>
+                  <div class="flex items-center gap-2 text-sm font-semibold text-slate-900 dark:text-white">
+                    <span aria-hidden class="inline-flex size-9 items-center justify-center rounded-full bg-[#ff8c00] text-white">
+                      M
+                    </span>
+                    <span class="text-xs uppercase tracking-wide text-slate-600 dark:text-slate-200">СВАО</span>
+                  </div>
+                </div>
+                <a
+                  href="https://pika.technopark-rgsu.ru/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-sky-600 hover:text-sky-700 dark:text-sky-300 dark:hover:text-sky-200"
+                >
+                  <span>VR‑тур по площадке ВДНХ</span>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    class="h-4 w-4"
+                  >
+                    <path d="M5 12h14" stroke-linecap="round" />
+                    <path d="m13 6 6 6-6 6" stroke-linecap="round" stroke-linejoin="round" />
+                  </svg>
+                </a>
+              </div>
+              <div class="rounded-2xl bg-white/70 dark:bg-slate-800/70 border border-slate-200 dark:border-slate-700 p-4 shadow-sm">
+                <div class="flex items-start justify-between gap-3">
+                  <div>
+                    <div class="font-semibold text-slate-900 dark:text-white">
+                      Беговая
+                    </div>
+                    <div>ул. Беговая, 12</div>
+                  </div>
+                  <div class="flex items-center gap-2 text-sm font-semibold text-slate-900 dark:text-white">
+                    <span aria-hidden class="inline-flex size-9 items-center justify-center rounded-full bg-[#a6007a] text-white">
+                      M
+                    </span>
+                    <span class="text-xs uppercase tracking-wide text-slate-600 dark:text-slate-200">САО</span>
+                  </div>
+                </div>
+                <a
+                  href="https://begovaya.technopark-rgsu.ru/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-emerald-600 hover:text-emerald-700 dark:text-emerald-300 dark:hover:text-emerald-200"
+                >
+                  <span>VR‑тур по площадке Беговая</span>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    class="h-4 w-4"
+                  >
+                    <path d="M5 12h14" stroke-linecap="round" />
+                    <path d="m13 6 6 6-6 6" stroke-linecap="round" stroke-linejoin="round" />
+                  </svg>
+                </a>
+              </div>
+            </div>
+            <div
+              class="surface-card-base relative w-full overflow-hidden rounded-3xl border border-slate-200 dark:border-slate-700 bg-white/80 dark:bg-slate-900/60 shadow-inner aspect-video"
+            >
+              <iframe
+                id="map-vdnkh"
+                title="Карта — ВДНХ"
+                class="absolute inset-0 w-full h-full"
+                data-map="0"
+                src="https://yandex.ru/map-widget/v1/?lang=ru_RU&scroll=false&mode=search&text=%D1%83%D0%BB.%20%D0%92%D0%B8%D0%BB%D1%8C%D0%B3%D0%B5%D0%BB%D1%8C%D0%BC%D0%B0%20%D0%9F%D0%B8%D0%BA%D0%B0,%204,%20%D0%BA%D0%BE%D1%80%D0%BF.%208"
+                loading="lazy"
+                allowfullscreen
+                aria-hidden="false"
+              ></iframe>
+              <iframe
+                id="map-begovaya"
+                title="Карта — Беговая"
+                class="absolute inset-0 w-full h-full opacity-0 pointer-events-none"
+                data-map="1"
+                src="https://yandex.ru/map-widget/v1/?lang=ru_RU&scroll=false&mode=search&text=%D1%83%D0%BB.%20%D0%91%D0%B5%D0%B3%D0%BE%D0%B2%D0%B0%D1%8F,%2012"
+                loading="lazy"
+                allowfullscreen
+                aria-hidden="true"
+                tabindex="-1"
+              ></iframe>
+            </div>
+
               © <span id="y"></span> Технопарк РГСУ
             </div>
           </div>
@@ -1574,7 +1647,7 @@
             </div>
           </div>
           <div
-            class="mt-10 flex flex-wrap items-center justify-between gap-4 text-xs text-slate-500 dark:text-slate-400"
+            class="mt-10 flex flex-wrap items-center justify-between gap-4 text-xs text-slate-600 dark:text-slate-200"
           >
             <div class="flex flex-wrap gap-3">
               <a href="#" class="hover:underline">Конфиденциальность</a
@@ -1592,7 +1665,7 @@
               </select>
             </div>
           </div>
-          <div class="mt-6 text-xs text-slate-500 dark:text-slate-400">
+          <div class="mt-6 text-xs text-slate-600 dark:text-slate-200">
             © <span id="y2"></span> Step3D.Lab · Все права защищены
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add a reusable gradient CTA style and apply it to all “Оставить заявку” buttons on both pages
- refresh top navigation highlighting and limit the links to “Главная” and “ДПО R22 и A” for the home page
- align the contact footer markup across the site so the landing and course pages share the same layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d447b2ce4883339fdcd82c42334e76