### PR TITLE
Bold key program parameters

### DIFF
--- a/reverse-additive.html
+++ b/reverse-additive.html
@@ -1028,7 +1028,9 @@
                     >
                       Продолжительность
                     </dt>
-                    <dd class="mt-1 text-base">48 академических часов</dd>
+                    <dd class="mt-1 text-base">
+                      <strong>48 академических часов</strong>
+                    </dd>
                   </div>
                   <div>
                     <dt
@@ -1036,7 +1038,9 @@
                     >
                       Группа
                     </dt>
-                    <dd class="mt-1 text-base">6–12 участников</dd>
+                    <dd class="mt-1 text-base">
+                      <strong>6–12 участников</strong>
+                    </dd>
                   </div>
                   <div>
                     <dt
@@ -1054,7 +1058,11 @@
                     >
                       Стоимость
                     </dt>
-                    <dd class="mt-1 text-base">68 000 ₽ за участника</dd>
+                    <dd class="mt-1 text-base">
+                      <strong>68 000 ₽ за участника очно</strong><br />
+                      <strong>45 000 рублей дистанционно</strong><br />
+                      <strong>23 000 рублей самостоятельном обучение по материалам курса</strong>
+                    </dd>
                   </div>
                   <div>
                     <dt
@@ -1063,7 +1071,7 @@
                       Место
                     </dt>
                     <dd class="mt-1 text-base">
-                      Москва, ул. Беговая, д. 12 (технопарк РГСУ)
+                      <strong>Москва, ул. Беговая, д. 12 / Яндекс-телемост (при дистанционном режиме)</strong>
                     </dd>
                   </div>
                 </dl>


### PR DESCRIPTION
## Summary
- highlight the duration, group size, location, and cost details within the "Параметры программы" section using bold text
- update the cost entry to list separate prices for in-person, remote, and self-study formats
- revise the location entry to mention both the Moscow venue and the Yandex teleconference option for remote sessions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d46a4334b08333b5a09500e2fcb768