### PR TITLE
Replace map embeds with VR tour tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2129,7 +2129,7 @@
                   <h3 class="text-lg font-semibold text-slate-900 dark:text-white">
                     Площадки Step3D.Lab
                   </h3>
-                  <div class="flex gap-2" role="tablist" aria-label="Переключение карт">
+                  <div class="flex gap-2" role="tablist" aria-label="Переключение VR-туров">
                     <button
                       class="px-3 py-1.5 rounded-xl text-sm font-medium text-white bg-slate-900 dark:bg-white dark:text-slate-900 shadow-sm"
                       data-maptab="0"
@@ -2226,21 +2226,23 @@
             >
               <iframe
                 id="map-vdnkh"
-                title="Карта — ВДНХ"
+                title="VR‑тур — ВДНХ"
                 class="absolute inset-0 w-full h-full"
                 data-map="0"
-                src="https://yandex.ru/map-widget/v1/?lang=ru_RU&scroll=false&mode=search&text=%D1%83%D0%BB.%20%D0%92%D0%B8%D0%BB%D1%8C%D0%B3%D0%B5%D0%BB%D1%8C%D0%BC%D0%B0%20%D0%9F%D0%B8%D0%BA%D0%B0,%204,%20%D0%BA%D0%BE%D1%80%D0%BF.%208"
+                src="https://pika.technopark-rgsu.ru/"
                 loading="lazy"
+                allow="accelerometer; gyroscope; fullscreen"
                 allowfullscreen
                 aria-hidden="false"
               ></iframe>
               <iframe
                 id="map-begovaya"
-                title="Карта — Беговая"
+                title="VR‑тур — Беговая"
                 class="absolute inset-0 w-full h-full opacity-0 pointer-events-none"
                 data-map="1"
-                src="https://yandex.ru/map-widget/v1/?lang=ru_RU&scroll=false&mode=search&text=%D1%83%D0%BB.%20%D0%91%D0%B5%D0%B3%D0%BE%D0%B2%D0%B0%D1%8F,%2012"
+                src="https://begovaya.technopark-rgsu.ru/"
                 loading="lazy"
+                allow="accelerometer; gyroscope; fullscreen"
                 allowfullscreen
                 aria-hidden="true"
                 tabindex="-1"


### PR DESCRIPTION
## Summary
- update the address section tablist label to reference VR tours
- swap Yandex map iframes for embedded VR tour experiences for ВДНХ and Беговая

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d46b558e388333af52d470af8e06c4