### PR TITLE
Add RGSU logo above course duration badge

### DIFF
--- a/reverse-additive.html
+++ b/reverse-additive.html
@@ -395,6 +395,13 @@
           id="overview"
         >
           <div>
+            <div class="mb-4">
+              <img
+                src="Российский_государственный_социальный_университет.png"
+                alt="Логотип Российского государственного социального университета"
+                class="h-16 w-auto"
+              />
+            </div>
             <span
               class="inline-flex items-center rounded-full border border-slate-200 dark:border-slate-700 px-3 py-1 text-xs uppercase tracking-wider text-slate-500 dark:text-slate-300"
               >Курс ДПО · 48 часов</span


### PR DESCRIPTION
## Summary
- display the Russian State Social University logo above the course duration badge on the reverse additive page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d470d99d6483339f3263a12a8a6c97