### PR TITLE
Update course descriptions and FAQ naming

### DIFF
--- a/index.html
+++ b/index.html
@@ -451,44 +451,55 @@
     </div>
   </section>
 
-  <!-- Курсы ДПО -->
+  <!-- Обучение и мастер-классы -->
   <section id="courses" class="py-16 md:py-24 bg-white dark:bg-slate-900">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <h2 class="text-3xl md:text-4xl font-bold mb-6">Курсы ДПО и проектные школы</h2>
-      <p class="text-slate-600 dark:text-slate-300 max-w-3xl">Образовательный партнёр ФГБОУ ВО РГСУ — гос. регистрация: ОГРН 1027739469468, ИНН 7726039659, КПП 771401001.</p>
-      <details class="mt-4 rounded-2xl border border-slate-200 dark:border-slate-700 p-4 open:shadow-sm">
-        <summary class="cursor-pointer font-medium">Образовательный партнёр ФГБОУ ВО РГСУ — гос. регистрация: ОГРН 1027739469468, ИНН 7726039659, КПП 771401001</summary>
-        <ul class="mt-3 list-disc pl-5 text-sm text-slate-600 dark:text-slate-300">
-          <li>Знакомство со сканерами, подготовка объекта</li>
-          <li>Обработка сеток: чистка, выравнивание, ремешинг</li>
-          <li>Восстановление поверхностей / NURBS</li>
-          <li>CAD‑проектирование и контроль</li>
-          <li>Подготовка к печати, постобработка</li>
-        </ul>
-      </details>
+      <h2 class="text-3xl md:text-4xl font-bold mb-6">Обучение и мастер-классы</h2>
       <div class="mt-8 grid sm:grid-cols-2 gap-6 md:gap-8">
-        <a class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm hover:shadow-md transition-shadow dark:border-slate-700 dark:bg-slate-800 block focus:outline-none focus:ring-4 focus:ring-slate-200 dark:focus:ring-slate-700" href="#">
+        <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm transition-shadow dark:border-slate-700 dark:bg-slate-800 block">
           <div class="flex items-start justify-between gap-4">
             <div>
               <div class="flex items-center gap-3">
-                <svg viewBox="0 0 64 64" class="h-10 w-10" aria-hidden><defs><linearGradient id="c1" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0ea5e9"/><stop offset="1" stop-color="#22c55e"/></linearGradient></defs><rect x="6" y="6" width="52" height="52" rx="12" fill="url(#c1)"/><path d="M20 44V20l12-6 12 6v24l-12 6-12-6z M32 14v36" stroke="#fff" stroke-width="2" fill="none"/></svg>
-                <h3 class="text-xl font-semibold leading-tight hover:underline underline-offset-4">Промышленный дизайн и инжиниринг</h3>
+                <svg viewBox="0 0 64 64" class="h-10 w-10" aria-hidden><defs><linearGradient id="c1" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#facc15"/><stop offset="1" stop-color="#f97316"/></linearGradient></defs><rect x="6" y="6" width="52" height="52" rx="12" fill="url(#c1)"/><path d="M20 44V20l12-6 12 6v24l-12 6-12-6z M32 14v36" stroke="#fff" stroke-width="2" fill="none"/></svg>
+                <h3 class="text-xl font-semibold leading-tight">4DI.01 «Промышленный дизайн и инжиниринг»</h3>
               </div>
               <p class="mt-2 text-slate-600 dark:text-slate-300">CAD, прототипирование, аддитивные технологии</p>
-              <div class="mt-3 flex flex-wrap gap-2 text-sm text-slate-500 dark:text-slate-300"><span class="inline-flex items-center rounded-lg bg-slate-100 dark:bg-slate-700 px-2.5 py-1">72 ч</span><span class="inline-flex items-center rounded-lg bg-slate-100 dark:bg-slate-700 px-2.5 py-1">7–11 класс, студенты</span></div>
+              <div class="mt-3 flex flex-wrap gap-2 text-xs sm:text-sm text-slate-600 dark:text-slate-300">
+                <span class="inline-flex items-center gap-1 rounded-full bg-gradient-to-r from-amber-200 via-yellow-200 to-orange-200 px-3 py-1 font-semibold text-amber-900 shadow-sm">Бесплатно · грант ДОиН г. Москвы «Инженерный класс»</span>
+                <span class="inline-flex items-center rounded-lg bg-slate-100 dark:bg-slate-700 px-2.5 py-1">72 ч</span>
+                <span class="inline-flex items-center rounded-lg bg-slate-100 dark:bg-slate-700 px-2.5 py-1">7–11 класс, студенты</span>
+              </div>
+              <div class="mt-4 grid gap-2 text-sm text-slate-500 dark:text-slate-300">
+                <div class="flex flex-wrap items-center gap-2">
+                  <span class="inline-flex items-center rounded-lg bg-amber-100 px-2.5 py-1 text-amber-900">Старт 8 сентября 2025</span>
+                  <span class="inline-flex items-center rounded-lg bg-amber-100 px-2.5 py-1 text-amber-900">Финиш 22 декабря 2025</span>
+                </div>
+                <div class="inline-flex items-center gap-2 text-slate-600 dark:text-slate-300">
+                  <span class="inline-flex items-center rounded-lg bg-slate-100 dark:bg-slate-700 px-2.5 py-1 font-medium text-slate-800 dark:text-slate-100">Группа укомплектована</span>
+                  <span>22 / 22 участников</span>
+                </div>
+              </div>
             </div>
-            <svg viewBox="0 0 24 24" class="mt-1 h-5 w-5 text-slate-400"><path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            <span class="mt-1 inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-900">Набор закрыт</span>
           </div>
-        </a>
+        </div>
         <a class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm hover:shadow-md transition-shadow dark:border-slate-700 dark:bg-slate-800 block focus:outline-none focus:ring-4 focus:ring-slate-200 dark:focus:ring-slate-700" href="reverse-additive.html">
           <div class="flex items-start justify-between gap-4">
             <div>
               <div class="flex items-center gap-3">
                 <svg viewBox="0 0 64 64" class="h-10 w-10" aria-hidden><defs><linearGradient id="c2" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0ea5e9"/><stop offset="1" stop-color="#22c55e"/></linearGradient></defs><rect x="6" y="6" width="52" height="52" rx="12" fill="url(#c2)"/><path d="M20 44V20l12-6 12 6v24l-12 6-12-6z M32 14v36" stroke="#fff" stroke-width="2" fill="none"/></svg>
-                <h3 class="text-xl font-semibold leading-tight hover:underline underline-offset-4">Реверсивный инжиниринг и аддитивное производство</h3>
+                <h3 class="text-xl font-semibold leading-tight hover:underline underline-offset-4">ДПО R22.AM «Реверсивный инжиниринг и аддитивное производство»</h3>
               </div>
               <p class="mt-2 text-slate-600 dark:text-slate-300">3D‑сканирование, обработка сканов, CAD, 3D‑печать</p>
-              <div class="mt-3 flex flex-wrap gap-2 text-sm text-slate-500 dark:text-slate-300"><span class="inline-flex items-center rounded-lg bg-slate-100 dark:bg-slate-700 px-2.5 py-1">48–72 ч</span><span class="inline-flex items-center rounded-lg bg-slate-100 dark:bg-slate-700 px-2.5 py-1">Студенты и специалисты</span></div>
+              <div class="mt-3 flex flex-wrap gap-2 text-sm text-slate-500 dark:text-slate-300">
+                <span class="inline-flex items-center rounded-lg bg-slate-100 dark:bg-slate-700 px-2.5 py-1">48–72 ч</span>
+                <span class="inline-flex items-center rounded-lg bg-slate-100 dark:bg-slate-700 px-2.5 py-1">Студенты и специалисты</span>
+                <span class="inline-flex items-center rounded-lg bg-slate-100 dark:bg-slate-700 px-2.5 py-1 font-semibold text-slate-800 dark:text-slate-100">Стоимость: 48 000 ₽</span>
+              </div>
+              <div class="mt-3 flex flex-wrap gap-3 text-sm text-slate-500 dark:text-slate-300">
+                <span class="inline-flex items-center gap-2 rounded-lg bg-slate-100 dark:bg-slate-700 px-2.5 py-1"><svg viewBox="0 0 20 20" class="h-4 w-4" aria-hidden><path d="M10 2a8 8 0 1 0 8 8 8.01 8.01 0 0 0-8-8Zm3.53 8.53-3.25 3.25a.75.75 0 0 1-1.06-1.06l2.97-2.97V6.75a.75.75 0 0 1 1.5 0v3.28a.75.75 0 0 1-.16.47Z" fill="currentColor"/></svg>Старт через 24 дня</span>
+                <span class="inline-flex items-center gap-2 rounded-lg bg-slate-100 dark:bg-slate-700 px-2.5 py-1"><svg viewBox="0 0 20 20" class="h-4 w-4" aria-hidden><path d="M3 5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Zm12.5 3H4.5v7a.5.5 0 0 0 .5.5h10a.5.5 0 0 0 .5-.5Zm-10-4a.5.5 0 0 0-.5.5V7h11V4.5a.5.5 0 0 0-.5-.5Z" fill="currentColor"/></svg>Свободно 11 из 12 мест</span>
+              </div>
             </div>
             <svg viewBox="0 0 24 24" class="mt-1 h-5 w-5 text-slate-400"><path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </div>
@@ -532,7 +543,7 @@
   <!-- FAQ -->
   <section id="faq" class="py-16 md:py-24 bg-white dark:bg-slate-900">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <h2 class="text-3xl md:text-4xl font-bold mb-6">FAQ</h2>
+      <h2 class="text-3xl md:text-4xl font-bold mb-6">FAQ (часто задаваемые вопросы)</h2>
       <div class="grid md:grid-cols-2 gap-6 md:gap-8">
         <details class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm open:shadow-md dark:border-slate-700 dark:bg-slate-800"><summary class="cursor-pointer font-medium">Какие материалы печати доступны?</summary><p class="mt-2 text-slate-600 dark:text-slate-300">PLA, PETG, ABS, нейлон; смолы DLP/SLA (стандартные и инженерные). Постобработка и окраска — доступны.</p></details>
         <details class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm open:shadow-md dark:border-slate-700 dark:bg-slate-800"><summary class="cursor-pointer font-medium">Сколько занимает цикл «скан‑CAD‑печать»?</summary><p class="mt-2 text-slate-600 dark:text-slate-300">От 2 до 10 рабочих дней — зависит от размера, точности и загрузки.</p></details>
@@ -644,7 +655,7 @@
   </div>
 
   <!-- Секции для навигации (для автоподсветки) -->
-  <div id="nav-data" class="hidden" data-nav='[{"id":"services","label":"Возможности"},{"id":"equipment","label":"Оборудование"},{"id":"projects","label":"Проекты"},{"id":"courses","label":"Курсы"},{"id":"team","label":"Команда"},{"id":"faq","label":"FAQ"},{"id":"contacts","label":"Контакты"}]'></div>
+  <div id="nav-data" class="hidden" data-nav='[{"id":"services","label":"Возможности"},{"id":"equipment","label":"Оборудование"},{"id":"projects","label":"Проекты"},{"id":"courses","label":"Обучение"},{"id":"team","label":"Команда"},{"id":"faq","label":"FAQ (часто задаваемые вопросы)"},{"id":"contacts","label":"Контакты"}]'></div>
 
   <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
 

--- a/reverse-additive.html
+++ b/reverse-additive.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Step3D.Lab — Курс «Реверсивный инжиниринг и аддитивное производство»</title>
-  <meta name="description" content="Практический курс ДПО по реверсивному инжинирингу и аддитивному производству: 3D-сканирование, CAD, 3D-печать, календарно-тематический план и команда преподавателей технопарка РГСУ." />
+  <title>Step3D.Lab — Курс «ДПО R22.AM „Реверсивный инжиниринг и аддитивное производство“»</title>
+  <meta name="description" content="Практический курс ДПО R22.AM по реверсивному инжинирингу и аддитивному производству: 3D-сканирование, CAD, 3D-печать, календарно-тематический план и команда преподавателей технопарка РГСУ." />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><rect x='6' y='6' width='52' height='52' rx='12' fill='%230ea5e9'/><path d='M20 44V20l12-6 12 6v24l-12 6-12-6z M32 14v36' stroke='%23fff' stroke-width='2' fill='none'/></svg>">
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
@@ -51,8 +51,8 @@
 
       <div class="grid lg:grid-cols-[1.1fr,0.9fr] gap-10 md:gap-16 items-center" id="overview">
         <div>
-          <span class="inline-flex items-center rounded-full border border-slate-200 dark:border-slate-700 px-3 py-1 text-xs uppercase tracking-wider text-slate-500 dark:text-slate-300">Курс ДПО · 48 часов</span>
-          <h1 class="mt-4 text-4xl md:text-5xl font-extrabold tracking-tight leading-tight">«Реверсивный инжиниринг и аддитивное производство»</h1>
+          <span class="inline-flex items-center rounded-full border border-slate-200 dark:border-slate-700 px-3 py-1 text-xs uppercase tracking-wider text-slate-500 dark:text-slate-300">Курс ДПО R22.AM · 48 часов</span>
+          <h1 class="mt-4 text-4xl md:text-5xl font-extrabold tracking-tight leading-tight">«ДПО R22.AM “Реверсивный инжиниринг и аддитивное производство”»</h1>
           <p class="mt-4 text-lg text-slate-600 dark:text-slate-300 max-w-prose">Интенсивное обучение для инженеров и технологов: оцифровка изделий, восстановление CAD‑моделей и изготовление оснастки и деталей с применением аддитивных технологий. Программа выстроена вокруг реальных задач промышленности и чемпионатов профессионального мастерства.</p>
           <div class="mt-6 flex flex-wrap gap-3">
             <button id="openModal" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-5 py-3 text-white font-medium shadow hover:bg-slate-800 focus:outline-none focus:ring-4 focus:ring-slate-300">Оставить заявку</button>
@@ -133,7 +133,7 @@
             </div>
           </div>
         </div>
-        <h2 class="text-3xl md:text-4xl font-bold mb-6">Практические блоки</h2>
+        <h2 class="text-3xl md:text-4xl font-bold mb-6">Практические блоки курса ДПО R22.AM</h2>
         <div class="grid lg:grid-cols-3 gap-6 md:gap-8">
           <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
             <h3 class="text-lg font-semibold">3D‑сканирование</h3>
@@ -308,7 +308,7 @@
               <ul class="mt-2 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc pl-5">
                 <li>Доступ к методическим материалам и видеолекциям преподавателей.</li>
                 <li>Индивидуальные консультации по внедрению аддитивных технологий.</li>
-                <li>Возможность продолжить обучение на курсах «Промышленный дизайн и инжиниринг» и «Инженерный дизайн (САПР)».</li>
+                <li>Возможность продолжить обучение на программах «4DI.01 “Промышленный дизайн и инжиниринг”» и «Инженерный дизайн (САПР)».</li>
               </ul>
             </div>
           </div>
@@ -342,7 +342,7 @@
                 <p class="mt-1 text-sm text-slate-500 dark:text-slate-300">Руководитель технопарка РГСУ, тренер сборной России по реверсивному инжинирингу (2019–2021), преподаватель и разработчик программ ДПО.</p>
                 <ul class="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc pl-5">
                   <li>Опыт подготовки чемпионов WorldSkills и BRICS, экспертиза в САПР и внедрении ЧПУ.</li>
-                  <li>Преподаватель курсов «Промышленный дизайн и инжиниринг», «Инженерный дизайн (САПР)».</li>
+                  <li>Преподаватель курсов «4DI.01 “Промышленный дизайн и инжиниринг”», «Инженерный дизайн (САПР)».</li>
                   <li>Автор видеолекций по методологии технического образования, наставник ИТ-классов.</li>
                 </ul>
               </div>
@@ -391,7 +391,7 @@
             <div>
               <h3 class="text-lg font-semibold">Связанные программы</h3>
               <ul class="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300 list-disc pl-5">
-                <li><a class="hover:underline" href="index.html#courses">Промышленный дизайн и инжиниринг (72 ч)</a></li>
+                <li><a class="hover:underline" href="index.html#courses">4DI.01 «Промышленный дизайн и инжиниринг» (72 ч)</a></li>
                 <li><a class="hover:underline" href="index.html#courses">Инженерный дизайн (САПР)</a></li>
               </ul>
             </div>


### PR DESCRIPTION
## Summary
- rename the learning section to "Обучение и мастер-классы", remove the outdated partner details, and refresh the cards with new availability, grant and pricing information
- expand the FAQ heading and navigation labels to clarify the section purpose
- align the dedicated course page with the new ДПО R22.AM naming and references to the updated 4DI.01 programme

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4c7a6cb8c833380b1b175991aee56