### PR TITLE
Revamp service calculator UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -354,40 +354,58 @@
             <li class="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 flex items-center justify-between"><span class="font-medium">Formlabs (DLP/SLA)</span><span class="text-sm text-slate-500">—</span></li>
           </ul>
         </div>
-        <div class="rounded-3xl border border-slate-200 dark:border-slate-700 p-6 bg-slate-50/60 dark:bg-slate-800/60">
-          <div class="flex flex-col gap-4">
-            <div>
-              <h3 class="text-lg font-semibold leading-tight">Экспресс-калькулятор услуг</h3>
-              <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">Прикиньте бюджет на 3D‑печать, моделирование, сканирование или реверсивный инжиниринг до заявки.</p>
+        <div class="relative overflow-hidden rounded-3xl border border-slate-200/70 bg-gradient-to-br from-white/80 via-sky-50/60 to-slate-50/90 p-6 lg:p-8 shadow-soft dark:border-slate-700/70 dark:from-slate-900/80 dark:via-slate-900/70 dark:to-slate-800/80">
+          <span class="pointer-events-none absolute -top-20 -right-6 h-56 w-56 rounded-full bg-sky-200/30 blur-2xl dark:bg-sky-500/20"></span>
+          <span class="pointer-events-none absolute -bottom-24 -left-10 h-56 w-56 rounded-full bg-emerald-200/30 blur-2xl dark:bg-emerald-500/20"></span>
+          <div class="relative z-10 flex flex-col gap-6">
+            <div class="flex flex-wrap items-start gap-4">
+              <div class="rounded-2xl bg-white/70 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-slate-500 shadow-sm dark:bg-slate-900/60 dark:text-slate-300">Смета за минуту</div>
+              <div class="rounded-2xl bg-white/70 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-slate-500 shadow-sm dark:bg-slate-900/60 dark:text-slate-300">Персонализированные сценарии</div>
+            </div>
+            <div class="flex flex-col gap-2">
+              <h3 class="text-2xl font-semibold leading-tight text-slate-900 dark:text-slate-100">Экспресс-калькулятор услуг</h3>
+              <p class="text-sm text-slate-600 dark:text-slate-300 max-w-xl">Прикиньте бюджет на 3D‑печать, моделирование, сканирование или реверсивный инжиниринг до заявки, а затем отправьте результат менеджеру в один клик.</p>
             </div>
             <div class="flex flex-wrap gap-2">
-              <button type="button" class="js-service-tab inline-flex items-center gap-1 rounded-xl px-3 py-2 text-sm font-medium border border-slate-200 bg-white shadow-sm hover:border-sky-300 hover:text-sky-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400" data-service="print" data-active>
-                <span class="size-1.5 rounded-full bg-emerald-400"></span>3D‑печать
+              <button type="button" class="js-service-tab inline-flex items-center gap-2 rounded-2xl border border-slate-200/70 bg-white/90 px-4 py-2 text-sm font-medium text-slate-600 transition-all duration-200 hover:-translate-y-0.5 hover:border-sky-300 hover:text-slate-900 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-200 dark:hover:border-sky-400 dark:hover:text-white dark:focus-visible:ring-offset-slate-900" data-service="print" data-active>
+                <span class="flex size-6 items-center justify-center rounded-xl bg-emerald-100 text-emerald-500 shadow-inner dark:bg-emerald-500/30 dark:text-emerald-200">
+                  <svg viewBox="0 0 20 20" fill="currentColor" class="size-3.5"><path d="M3.75 4A1.75 1.75 0 0 1 5.5 2.25h9A1.75 1.75 0 0 1 16.25 4v2.75h.5a.75.75 0 0 1 .75.75v6.5a2.75 2.75 0 0 1-2.75 2.75H5.25A2.75 2.75 0 0 1 2.5 14V7.5a.75.75 0 0 1 .75-.75h.5V4Zm1.5 0v2.75h9V4a.25.25 0 0 0-.25-.25h-9A.25.25 0 0 0 5.25 4Zm-1.75 4V14c0 .69.56 1.25 1.25 1.25h9.5c.69 0 1.25-.56 1.25-1.25V8H3.5Z"/></svg>
+                </span>
+                3D‑печать
               </button>
-              <button type="button" class="js-service-tab inline-flex items-center gap-1 rounded-xl px-3 py-2 text-sm font-medium border border-slate-200 bg-white shadow-sm hover:border-sky-300 hover:text-sky-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400" data-service="modeling">
-                <span class="size-1.5 rounded-full bg-sky-400"></span>3D‑моделирование
+              <button type="button" class="js-service-tab inline-flex items-center gap-2 rounded-2xl border border-slate-200/70 bg-white/90 px-4 py-2 text-sm font-medium text-slate-600 transition-all duration-200 hover:-translate-y-0.5 hover:border-sky-300 hover:text-slate-900 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-200 dark:hover:border-sky-400 dark:hover:text-white dark:focus-visible:ring-offset-slate-900" data-service="modeling">
+                <span class="flex size-6 items-center justify-center rounded-xl bg-sky-100 text-sky-500 shadow-inner dark:bg-sky-500/30 dark:text-sky-200">
+                  <svg viewBox="0 0 20 20" fill="currentColor" class="size-3.5"><path d="M9.03 2.23a1.75 1.75 0 0 1 1.94 0l5.5 3.57c.49.32.78.87.78 1.46v5.48c0 .59-.29 1.14-.78 1.46l-5.5 3.57a1.75 1.75 0 0 1-1.94 0l-5.5-3.57A1.75 1.75 0 0 1 2.75 12.74V7.26c0-.59.29-1.14.78-1.46l5.5-3.57ZM4.25 7.45v5.1l4.75 3.08V10.5L4.25 7.45Zm6.75 8.18 4.75-3.08v-5.1l-4.75 3.05v5.13ZM5.04 6.1 10 9.3l4.96-3.2L10 2.9 5.04 6.1Z"/></svg>
+                </span>
+                3D‑моделирование
               </button>
-              <button type="button" class="js-service-tab inline-flex items-center gap-1 rounded-xl px-3 py-2 text-sm font-medium border border-slate-200 bg-white shadow-sm hover:border-sky-300 hover:text-sky-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400" data-service="scanning">
-                <span class="size-1.5 rounded-full bg-indigo-400"></span>3D‑сканирование
+              <button type="button" class="js-service-tab inline-flex items-center gap-2 rounded-2xl border border-slate-200/70 bg-white/90 px-4 py-2 text-sm font-medium text-slate-600 transition-all duration-200 hover:-translate-y-0.5 hover:border-sky-300 hover:text-slate-900 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-200 dark:hover:border-sky-400 dark:hover:text-white dark:focus-visible:ring-offset-slate-900" data-service="scanning">
+                <span class="flex size-6 items-center justify-center rounded-xl bg-indigo-100 text-indigo-500 shadow-inner dark:bg-indigo-500/30 dark:text-indigo-200">
+                  <svg viewBox="0 0 20 20" fill="currentColor" class="size-3.5"><path d="M4 5.5A1.5 1.5 0 0 1 5.5 4h9A1.5 1.5 0 0 1 16 5.5v9A1.5 1.5 0 0 1 14.5 16h-9A1.5 1.5 0 0 1 4 14.5v-9ZM5.5 5.5v9h9v-9h-9Zm1.75 1.5h5.5a.75.75 0 0 1 0 1.5h-5.5a.75.75 0 0 1 0-1.5Zm0 3h5.5a.75.75 0 0 1 0 1.5h-5.5a.75.75 0 0 1 0-1.5Zm0 3h3.5a.75.75 0 0 1 0 1.5h-3.5a.75.75 0 0 1 0-1.5Z"/></svg>
+                </span>
+                3D‑сканирование
               </button>
-              <button type="button" class="js-service-tab inline-flex items-center gap-1 rounded-xl px-3 py-2 text-sm font-medium border border-slate-200 bg-white shadow-sm hover:border-sky-300 hover:text-sky-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400" data-service="reverse">
-                <span class="size-1.5 rounded-full bg-amber-400"></span>Реверсивный инжиниринг
+              <button type="button" class="js-service-tab inline-flex items-center gap-2 rounded-2xl border border-slate-200/70 bg-white/90 px-4 py-2 text-sm font-medium text-slate-600 transition-all duration-200 hover:-translate-y-0.5 hover:border-sky-300 hover:text-slate-900 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-200 dark:hover:border-sky-400 dark:hover:text-white dark:focus-visible:ring-offset-slate-900" data-service="reverse">
+                <span class="flex size-6 items-center justify-center rounded-xl bg-amber-100 text-amber-500 shadow-inner dark:bg-amber-500/30 dark:text-amber-200">
+                  <svg viewBox="0 0 20 20" fill="currentColor" class="size-3.5"><path d="M4 5.75A1.75 1.75 0 0 1 5.75 4h8.5A1.75 1.75 0 0 1 16 5.75v2.2a.75.75 0 0 1-1.5 0v-2.2a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25v8.5c0 .14.11.25.25.25h2.2a.75.75 0 0 1 0 1.5h-2.2A1.75 1.75 0 0 1 4 14.25v-8.5Zm11.75 4a.75.75 0 0 1 .75.75v4.75A1.75 1.75 0 0 1 14.75 17.5H10a.75.75 0 0 1 0-1.5h4.75a.25.25 0 0 0 .25-.25V9.5a.75.75 0 0 1 .75-.75Zm-8 3.5A1.75 1.75 0 0 1 9.5 11.5h2a.75.75 0 0 1 0 1.5h-2a.25.25 0 0 0-.25.25v2a.75.75 0 0 1-1.5 0v-2Z"/></svg>
+                </span>
+                Реверсивный инжиниринг
               </button>
             </div>
 
-            <form class="rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900/70 space-y-4" id="serviceEstimator" novalidate>
+            <form class="rounded-2xl border border-slate-200/70 bg-white/90 p-5 shadow-sm backdrop-blur-sm dark:border-slate-700/70 dark:bg-slate-900/70 dark:shadow-none space-y-6" id="serviceEstimator" novalidate>
               <div data-service-form="print" class="grid gap-4 md:grid-cols-2">
                 <label class="flex flex-col gap-1 text-sm">
                   <span class="font-medium text-slate-700 dark:text-slate-200">Объем модели, см³</span>
-                  <input type="number" min="1" step="1" value="120" class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800/70" data-calc-input data-service="print" data-key="volume" />
+                  <input type="number" min="1" step="1" value="120" class="rounded-xl border border-slate-200/70 bg-slate-50/80 px-3 py-2 text-sm text-slate-800 shadow-inner transition focus:border-sky-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700/70 dark:bg-slate-800/70 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-500/40" data-calc-input data-service="print" data-key="volume" />
                 </label>
                 <label class="flex flex-col gap-1 text-sm">
                   <span class="font-medium text-slate-700 dark:text-slate-200">Количество копий</span>
-                  <input type="number" min="1" step="1" value="1" class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800/70" data-calc-input data-service="print" data-key="quantity" />
+                  <input type="number" min="1" step="1" value="1" class="rounded-xl border border-slate-200/70 bg-slate-50/80 px-3 py-2 text-sm text-slate-800 shadow-inner transition focus:border-sky-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700/70 dark:bg-slate-800/70 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-500/40" data-calc-input data-service="print" data-key="quantity" />
                 </label>
                 <label class="flex flex-col gap-1 text-sm">
                   <span class="font-medium text-slate-700 dark:text-slate-200">Материал</span>
-                  <select class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800/70" data-calc-input data-service="print" data-key="material">
+                  <select class="rounded-xl border border-slate-200/70 bg-slate-50/80 px-3 py-2 text-sm text-slate-800 shadow-inner transition focus:border-sky-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700/70 dark:bg-slate-800/70 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-500/40" data-calc-input data-service="print" data-key="material">
                     <option value="pla">PLA / PETG</option>
                     <option value="abs">ABS / нейлон</option>
                     <option value="resin">Фотополимер</option>
@@ -395,13 +413,13 @@
                 </label>
                 <label class="flex flex-col gap-2 text-sm md:col-span-2">
                   <span class="flex items-center justify-between font-medium text-slate-700 dark:text-slate-200">Сложность <span class="text-xs text-slate-500 dark:text-slate-400" id="printComplexityValue">средняя детализация</span></span>
-                  <input type="range" min="1" max="5" value="3" class="w-full accent-sky-500" data-calc-input data-service="print" data-key="complexity" data-output="printComplexityValue" />
+                  <input type="range" min="1" max="5" value="3" class="w-full accent-sky-500 [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-slate-200 [&::-webkit-slider-thumb]:size-4 [&::-webkit-slider-thumb]:-mt-1 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-sky-500 [&::-moz-range-track]:rounded-full [&::-moz-range-track]:bg-slate-200 [&::-moz-range-thumb]:size-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-sky-500 dark:[&::-webkit-slider-runnable-track]:bg-slate-700 dark:[&::-moz-range-track]:bg-slate-700" data-calc-input data-service="print" data-key="complexity" data-output="printComplexityValue" />
                 </label>
-                <label class="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+                <label class="inline-flex items-center gap-2 rounded-xl border border-slate-200/60 bg-slate-50/60 px-3 py-2 text-sm text-slate-700 shadow-inner transition hover:border-sky-300 hover:bg-white dark:border-slate-700/60 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:border-sky-400">
                   <input type="checkbox" class="size-4 rounded border-slate-300 text-sky-500 focus:ring-sky-500" data-calc-input data-service="print" data-key="finishing" />
                   Послепечатная обработка (шлифовка, грунт, покраска)
                 </label>
-                <label class="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+                <label class="inline-flex items-center gap-2 rounded-xl border border-slate-200/60 bg-slate-50/60 px-3 py-2 text-sm text-slate-700 shadow-inner transition hover:border-sky-300 hover:bg-white dark:border-slate-700/60 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:border-sky-400">
                   <input type="checkbox" class="size-4 rounded border-slate-300 text-sky-500 focus:ring-sky-500" data-calc-input data-service="print" data-key="urgent" />
                   Срочное изготовление (до 48 часов)
                 </label>
@@ -410,17 +428,17 @@
               <div data-service-form="modeling" class="grid gap-4 md:grid-cols-2 hidden">
                 <label class="flex flex-col gap-1 text-sm">
                   <span class="font-medium text-slate-700 dark:text-slate-200">Оценка трудоёмкости, часов</span>
-                  <input type="number" min="1" step="1" value="10" class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800/70" data-calc-input data-service="modeling" data-key="hours" />
+                  <input type="number" min="1" step="1" value="10" class="rounded-xl border border-slate-200/70 bg-slate-50/80 px-3 py-2 text-sm text-slate-800 shadow-inner transition focus:border-sky-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700/70 dark:bg-slate-800/70 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-500/40" data-calc-input data-service="modeling" data-key="hours" />
                 </label>
                 <label class="flex flex-col gap-2 text-sm md:col-span-2">
                   <span class="flex items-center justify-between font-medium text-slate-700 dark:text-slate-200">Уровень детализации <span class="text-xs text-slate-500 dark:text-slate-400" id="modelComplexityValue">функциональный прототип</span></span>
-                  <input type="range" min="1" max="5" value="3" class="w-full accent-sky-500" data-calc-input data-service="modeling" data-key="complexity" data-output="modelComplexityValue" />
+                  <input type="range" min="1" max="5" value="3" class="w-full accent-sky-500 [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-slate-200 [&::-webkit-slider-thumb]:size-4 [&::-webkit-slider-thumb]:-mt-1 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-sky-500 [&::-moz-range-track]:rounded-full [&::-moz-range-track]:bg-slate-200 [&::-moz-range-thumb]:size-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-sky-500 dark:[&::-webkit-slider-runnable-track]:bg-slate-700 dark:[&::-moz-range-track]:bg-slate-700" data-calc-input data-service="modeling" data-key="complexity" data-output="modelComplexityValue" />
                 </label>
-                <label class="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+                <label class="inline-flex items-center gap-2 rounded-xl border border-slate-200/60 bg-slate-50/60 px-3 py-2 text-sm text-slate-700 shadow-inner transition hover:border-sky-300 hover:bg-white dark:border-slate-700/60 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:border-sky-400">
                   <input type="checkbox" class="size-4 rounded border-slate-300 text-sky-500 focus:ring-sky-500" data-calc-input data-service="modeling" data-key="renders" />
                   Подготовить презентационные рендеры / инструкции
                 </label>
-                <label class="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+                <label class="inline-flex items-center gap-2 rounded-xl border border-slate-200/60 bg-slate-50/60 px-3 py-2 text-sm text-slate-700 shadow-inner transition hover:border-sky-300 hover:bg-white dark:border-slate-700/60 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:border-sky-400">
                   <input type="checkbox" class="size-4 rounded border-slate-300 text-sky-500 focus:ring-sky-500" data-calc-input data-service="modeling" data-key="consulting" />
                   Сопровождение инженера по внедрению
                 </label>
@@ -429,21 +447,21 @@
               <div data-service-form="scanning" class="grid gap-4 md:grid-cols-2 hidden">
                 <label class="flex flex-col gap-1 text-sm">
                   <span class="font-medium text-slate-700 dark:text-slate-200">Максимальный габарит, см</span>
-                  <input type="number" min="5" step="1" value="40" class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800/70" data-calc-input data-service="scanning" data-key="size" />
+                  <input type="number" min="5" step="1" value="40" class="rounded-xl border border-slate-200/70 bg-slate-50/80 px-3 py-2 text-sm text-slate-800 shadow-inner transition focus:border-sky-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700/70 dark:bg-slate-800/70 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-500/40" data-calc-input data-service="scanning" data-key="size" />
                 </label>
                 <label class="flex flex-col gap-1 text-sm">
                   <span class="font-medium text-slate-700 dark:text-slate-200">Количество объектов</span>
-                  <input type="number" min="1" step="1" value="1" class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800/70" data-calc-input data-service="scanning" data-key="count" />
+                  <input type="number" min="1" step="1" value="1" class="rounded-xl border border-slate-200/70 bg-slate-50/80 px-3 py-2 text-sm text-slate-800 shadow-inner transition focus:border-sky-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700/70 dark:bg-slate-800/70 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-500/40" data-calc-input data-service="scanning" data-key="count" />
                 </label>
                 <label class="flex flex-col gap-2 text-sm md:col-span-2">
                   <span class="flex items-center justify-between font-medium text-slate-700 dark:text-slate-200">Требуемая точность <span class="text-xs text-slate-500 dark:text-slate-400" id="scanDetailValue">0,1–0,2 мм</span></span>
-                  <input type="range" min="1" max="5" value="3" class="w-full accent-sky-500" data-calc-input data-service="scanning" data-key="detail" data-output="scanDetailValue" />
+                  <input type="range" min="1" max="5" value="3" class="w-full accent-sky-500 [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-slate-200 [&::-webkit-slider-thumb]:size-4 [&::-webkit-slider-thumb]:-mt-1 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-sky-500 [&::-moz-range-track]:rounded-full [&::-moz-range-track]:bg-slate-200 [&::-moz-range-thumb]:size-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-sky-500 dark:[&::-webkit-slider-runnable-track]:bg-slate-700 dark:[&::-moz-range-track]:bg-slate-700" data-calc-input data-service="scanning" data-key="detail" data-output="scanDetailValue" />
                 </label>
-                <label class="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+                <label class="inline-flex items-center gap-2 rounded-xl border border-slate-200/60 bg-slate-50/60 px-3 py-2 text-sm text-slate-700 shadow-inner transition hover:border-sky-300 hover:bg-white dark:border-slate-700/60 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:border-sky-400">
                   <input type="checkbox" class="size-4 rounded border-slate-300 text-sky-500 focus:ring-sky-500" data-calc-input data-service="scanning" data-key="texturing" />
                   Текстурирование / цветовая карта
                 </label>
-                <label class="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+                <label class="inline-flex items-center gap-2 rounded-xl border border-slate-200/60 bg-slate-50/60 px-3 py-2 text-sm text-slate-700 shadow-inner transition hover:border-sky-300 hover:bg-white dark:border-slate-700/60 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:border-sky-400">
                   <input type="checkbox" class="size-4 rounded border-slate-300 text-sky-500 focus:ring-sky-500" data-calc-input data-service="scanning" data-key="cleaning" />
                   Чистка и выравнивание сетки
                 </label>
@@ -452,11 +470,11 @@
               <div data-service-form="reverse" class="grid gap-4 md:grid-cols-2 hidden">
                 <label class="flex flex-col gap-1 text-sm">
                   <span class="font-medium text-slate-700 dark:text-slate-200">Количество деталей / узлов</span>
-                  <input type="number" min="1" step="1" value="3" class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800/70" data-calc-input data-service="reverse" data-key="parts" />
+                  <input type="number" min="1" step="1" value="3" class="rounded-xl border border-slate-200/70 bg-slate-50/80 px-3 py-2 text-sm text-slate-800 shadow-inner transition focus:border-sky-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700/70 dark:bg-slate-800/70 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-500/40" data-calc-input data-service="reverse" data-key="parts" />
                 </label>
                 <label class="flex flex-col gap-1 text-sm">
                   <span class="font-medium text-slate-700 dark:text-slate-200">Необходимость 2D‑документации</span>
-                  <select class="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800/70" data-calc-input data-service="reverse" data-key="drawings">
+                  <select class="rounded-xl border border-slate-200/70 bg-slate-50/80 px-3 py-2 text-sm text-slate-800 shadow-inner transition focus:border-sky-300 focus:bg-white focus:outline-none focus:ring-2 focus:ring-sky-200 dark:border-slate-700/70 dark:bg-slate-800/70 dark:text-slate-100 dark:focus:border-sky-400 dark:focus:ring-sky-500/40" data-calc-input data-service="reverse" data-key="drawings">
                     <option value="none">Нет, только 3D</option>
                     <option value="basic">Комплект эскизов</option>
                     <option value="full">Полный пакет КД</option>
@@ -464,25 +482,41 @@
                 </label>
                 <label class="flex flex-col gap-2 text-sm md:col-span-2">
                   <span class="flex items-center justify-between font-medium text-slate-700 dark:text-slate-200">Сложность узла <span class="text-xs text-slate-500 dark:text-slate-400" id="reverseComplexityValue">средний уровень</span></span>
-                  <input type="range" min="1" max="5" value="3" class="w-full accent-sky-500" data-calc-input data-service="reverse" data-key="complexity" data-output="reverseComplexityValue" />
+                  <input type="range" min="1" max="5" value="3" class="w-full accent-sky-500 [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-slate-200 [&::-webkit-slider-thumb]:size-4 [&::-webkit-slider-thumb]:-mt-1 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-sky-500 [&::-moz-range-track]:rounded-full [&::-moz-range-track]:bg-slate-200 [&::-moz-range-thumb]:size-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-sky-500 dark:[&::-webkit-slider-runnable-track]:bg-slate-700 dark:[&::-moz-range-track]:bg-slate-700" data-calc-input data-service="reverse" data-key="complexity" data-output="reverseComplexityValue" />
                 </label>
-                <label class="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+                <label class="inline-flex items-center gap-2 rounded-xl border border-slate-200/60 bg-slate-50/60 px-3 py-2 text-sm text-slate-700 shadow-inner transition hover:border-sky-300 hover:bg-white dark:border-slate-700/60 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:border-sky-400">
                   <input type="checkbox" class="size-4 rounded border-slate-300 text-sky-500 focus:ring-sky-500" data-calc-input data-service="reverse" data-key="analysis" />
                   Расчёт нагрузок / рекомендации по модернизации
                 </label>
-                <label class="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+                <label class="inline-flex items-center gap-2 rounded-xl border border-slate-200/60 bg-slate-50/60 px-3 py-2 text-sm text-slate-700 shadow-inner transition hover:border-sky-300 hover:bg-white dark:border-slate-700/60 dark:bg-slate-800/60 dark:text-slate-200 dark:hover:border-sky-400">
                   <input type="checkbox" class="size-4 rounded border-slate-300 text-sky-500 focus:ring-sky-500" data-calc-input data-service="reverse" data-key="pilot" />
                   Изготовить пилотную серию (3D‑печать / ЧПУ)
                 </label>
               </div>
             </form>
 
-            <div class="rounded-2xl bg-slate-900 text-slate-50 p-5 shadow-lg dark:bg-slate-800/90">
-              <p class="text-xs uppercase tracking-wide text-slate-400">Ориентировочная стоимость</p>
-              <div class="mt-1 text-3xl font-semibold"><span id="estimateTotal">—</span> ₽</div>
-              <ul class="mt-3 space-y-1 text-sm text-slate-200" id="estimateBreakdown"></ul>
-              <p class="mt-3 text-xs text-slate-400">Итоговая смета формируется после анализа ТЗ, материалов и исходных данных.</p>
-              <button type="button" id="openModalCalc" class="mt-4 inline-flex items-center justify-center rounded-xl border border-sky-300 bg-sky-500 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-sky-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-sky-300 dark:border-sky-400 dark:bg-sky-500/80">Оставить заявку с расчётом</button>
+            <div class="relative overflow-hidden rounded-2xl border border-slate-900/10 bg-slate-900 text-slate-50 p-6 shadow-xl shadow-slate-900/30 dark:border-slate-700/60 dark:bg-slate-900/80">
+              <span class="pointer-events-none absolute -top-20 -left-14 h-48 w-48 rounded-full bg-sky-500/40 blur-3xl"></span>
+              <span class="pointer-events-none absolute -bottom-16 -right-10 h-52 w-52 rounded-full bg-emerald-500/30 blur-3xl"></span>
+              <div class="relative z-10 flex flex-col gap-4">
+                <div>
+                  <p class="text-[11px] uppercase tracking-[0.32em] text-slate-400">Ориентировочная стоимость</p>
+                  <div class="mt-2 text-4xl font-semibold tracking-tight"><span id="estimateTotal">—</span> ₽</div>
+                  <p class="mt-2 text-xs text-slate-400">Расчёт обновляется моментально при изменении входных данных.</p>
+                </div>
+                <ul class="space-y-2 text-sm text-slate-200/90" id="estimateBreakdown"></ul>
+                <div class="rounded-xl border border-slate-700/60 bg-slate-900/40 p-3 text-[11px] leading-relaxed text-slate-300">
+                  Итоговая смета формируется после анализа ТЗ, материалов и исходных данных.
+                </div>
+                <div class="flex flex-wrap gap-2 text-[11px] uppercase tracking-wide text-slate-400">
+                  <span class="inline-flex items-center gap-1 rounded-full border border-slate-700/60 bg-slate-900/60 px-2 py-1"><span class="size-1.5 rounded-full bg-emerald-400/90"></span>PDF / Excel выгрузка</span>
+                  <span class="inline-flex items-center gap-1 rounded-full border border-slate-700/60 bg-slate-900/60 px-2 py-1"><span class="size-1.5 rounded-full bg-sky-400/90"></span>Передача менеджеру</span>
+                </div>
+                <button type="button" id="openModalCalc" class="inline-flex items-center justify-center gap-2 rounded-2xl border border-sky-400/60 bg-gradient-to-r from-sky-500 via-sky-400 to-emerald-400 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-sky-500/30 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 hover:scale-[1.01]">
+                  <svg viewBox="0 0 20 20" fill="currentColor" class="size-4"><path d="M2.93 2.3a.75.75 0 0 1 .82-.17l13 5a.75.75 0 0 1 .04 1.38l-4.9 2.3-2.3 4.9a.75.75 0 0 1-1.38-.04l-5-13a.75.75 0 0 1 .17-.82Zm1.76 1.44 3.47 9.02 1.62-3.46a.75.75 0 0 1 .36-.36l3.46-1.62-9.02-3.47Z"/></svg>
+                  Оставить заявку с расчётом
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -1057,7 +1091,7 @@
         tabs.forEach((tab) => {
           const isActive = tab.dataset.service === service
           const base = tab.dataset.baseClass
-          const activeState = ' bg-sky-500 text-white border-sky-500 shadow-md hover:text-white hover:border-sky-500'
+          const activeState = ' bg-slate-900 text-white border-slate-900 shadow-xl shadow-slate-900/30 hover:text-white hover:border-slate-900 dark:bg-slate-100/20 dark:text-white dark:border-slate-100/20'
           tab.className = isActive ? `${base}${activeState}` : base
           tab.setAttribute('aria-pressed', String(isActive))
         })


### PR DESCRIPTION
## Summary
- restyled the express services calculator with gradient card, hero chips, and icon tabs
- refreshed all calculator inputs and sliders with richer focus states and dark mode-ready styles
- redesigned the estimate summary card with feature chips, gradient accents, and upgraded CTA button

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d4f2ccf13083338f4eba9f76314779