### PR TITLE
Update branding and header visuals

### DIFF
--- a/Logo.svg
+++ b/Logo.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 48" role="img" aria-labelledby="title desc">
+  <title id="title">FabLabs R22</title>
+  <desc id="desc">Логотип сети FabLabs R22 с акцентом на 3D-печать</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0ea5e9" />
+      <stop offset="100%" stop-color="#22c55e" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fff" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#e0f2fe" stop-opacity="0.9" />
+    </linearGradient>
+  </defs>
+  <rect x="2" y="2" width="156" height="44" rx="14" fill="url(#bg)" />
+  <g fill="none" stroke="url(#accent)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M28 32V14h12c4.5 0 7.5 2.6 7.5 6.4 0 3.2-1.8 5.3-4.7 6.1l5.1 5.5" />
+    <path d="M64 32c0-6 4.2-10 9.6-10 5.6 0 9.4 4 9.4 10s-3.8 10-9.4 10C68.2 42 64 38 64 32Z" />
+    <path d="M101 18h22l-12 12h10l-16 12" />
+  </g>
+  <circle cx="132" cy="16" r="6" fill="#0f172a" opacity="0.35" />
+  <path d="M132 12v8m-4-4h8" stroke="#f8fafc" stroke-width="2" stroke-linecap="round" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Step3D.Lab — Лаборатория промдизайна и инжиниринга</title>
+  <title>Step3D.Lab — Лаборатория 3D-технологий</title>
   <meta name="description" content="CAD/CAE, реверсивный инжиниринг, 3D‑сканирование, аддитивное производство. Курсы ДПО, проекты, услуги технопарка РГСУ." />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><rect x='6' y='6' width='52' height='52' rx='12' fill='%230ea5e9'/><path d='M20 44V20l12-6 12 6v24l-12 6-12-6z M32 14v36' stroke='%23fff' stroke-width='2' fill='none'/></svg>">
   <!-- Tailwind (CDN, удобно для GitHub Pages). Для продакшна соберите локально. -->
@@ -478,7 +478,7 @@
   {
     "@context":"https://schema.org",
     "@type":"EducationalOrganization",
-    "name":"Step3D.Lab — Лаборатория промдизайна и инжиниринга",
+    "name":"Step3D.Lab — Лаборатория 3D-технологий",
     "department":[{"@type":"Organization","name":"Дополнительное профессиональное образование"}],
     "address":[
       {"@type":"PostalAddress","streetAddress":"ул. Беговая, 12","addressLocality":"Москва","addressCountry":"RU"}
@@ -502,7 +502,8 @@
       <nav class="mb-10" aria-label="Главная навигация">
         <div class="flex items-center justify-between gap-6">
           <a href="#top" class="flex items-center gap-3 font-semibold">
-            <svg viewBox="0 0 64 64" class="h-8 w-8"><defs><linearGradient id="g3d" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0ea5e9"/><stop offset="1" stop-color="#22c55e"/></linearGradient></defs><rect x="6" y="6" width="52" height="52" rx="12" fill="url(#g3d)"/><path d="M20 44V20l12-6 12 6v24l-12 6-12-6z M32 14v36" stroke="#fff" stroke-width="2" fill="none"/></svg>
+            <svg viewBox="0 0 64 64" class="h-12 w-12"><defs><linearGradient id="g3d" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0ea5e9"/><stop offset="1" stop-color="#22c55e"/></linearGradient></defs><rect x="6" y="6" width="52" height="52" rx="12" fill="url(#g3d)"/><path d="M20 44V20l12-6 12 6v24l-12 6-12-6z M32 14v36" stroke="#fff" stroke-width="2" fill="none"/></svg>
+            <img src="Logo.svg" alt="Логотип FabLabs R22" class="h-10 w-auto">
             <svg viewBox="0 0 32 32" class="h-6 w-6 text-slate-900 dark:text-slate-100"><rect x="6" y="8" width="4" height="4" rx="1" fill="currentColor"/><rect x="22" y="8" width="4" height="4" rx="1" fill="currentColor"/><rect x="8" y="12" width="16" height="4" fill="currentColor"/><rect x="4" y="16" width="24" height="4" fill="currentColor"/><rect x="8" y="20" width="4" height="4" fill="currentColor"/><rect x="20" y="20" width="4" height="4" fill="currentColor"/><rect x="12" y="24" width="8" height="4" fill="currentColor"/></svg>
             Step3D.Lab
           </a>
@@ -534,7 +535,7 @@
       <!-- Hero -->
       <div class="grid md:grid-cols-2 gap-10 md:gap-16 items-center" id="top">
         <div>
-          <h1 class="text-4xl md:text-6xl font-extrabold tracking-tight leading-tight">Лаборатория промдизайна и инжиниринга</h1>
+          <h1 class="text-4xl md:text-6xl font-extrabold tracking-tight leading-tight">Лаборатория 3D-технологий</h1>
           <p class="mt-4 text-lg text-slate-600 dark:text-slate-300 max-w-prose">Инженерный центр Step3D.Lab: цифровое проектирование, реверсивный инжиниринг, 3D‑сканирование и аддитивное производство. Команда технопарка РГСУ и ООО «СТЕП 3Д» выполняет разработки, сопровождает внедрение и обучает специалистов.</p>
           <div class="mt-6 flex flex-wrap gap-3">
             <button id="openModal" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-5 py-3 text-white font-medium shadow hover:bg-slate-800 focus:outline-none focus:ring-4 focus:ring-slate-300">Оставить заявку</button>
@@ -683,10 +684,10 @@
     </div>
   </section>
 
-  <!-- Оборудование и ПО -->
+  <!-- FabLabs R22 - распределенная сеть 3D-печати -->
   <section id="equipment" class="py-16 md:py-24 bg-white dark:bg-slate-900">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <h2 class="text-3xl md:text-4xl font-bold mb-6">Оборудование и ПО</h2>
+      <h2 class="text-3xl md:text-4xl font-bold mb-6">FabLabs R22 - распределенная сеть 3D-печати</h2>
       <p class="text-slate-600 dark:text-slate-300 max-w-3xl">3D‑сканеры RangeVision и Artec; принтеры FDM/DLP (Ultimaker, Picaso 3D, Formlabs); лазер Trotec, фрезерные Roland; GenAI и open-source инструменты: Perplexity AI, Qwen, Blender, FreeCAD, OpenSCAD, Hugging Face, T‑FLEX CAD.</p>
       <div class="mt-6 grid lg:grid-cols-2 gap-8">
         <div class="rounded-3xl border border-slate-200 dark:border-slate-700 p-4">
@@ -1240,7 +1241,7 @@
   </div>
 
   <!-- Секции для навигации (для автоподсветки) -->
-  <div id="nav-data" class="hidden" data-nav='[{"id":"services","label":"Возможности"},{"id":"equipment","label":"Оборудование"},{"id":"projects","label":"Проекты"},{"id":"courses","label":"Обучение"},{"id":"team","label":"Команда"},{"id":"faq","label":"FAQ (часто задаваемые вопросы)"},{"id":"contacts","label":"Контакты"}]'></div>
+  <div id="nav-data" class="hidden" data-nav='[{"id":"services","label":"Возможности"},{"id":"equipment","label":"FabLabs R22"},{"id":"projects","label":"Проекты"},{"id":"courses","label":"Обучение"},{"id":"team","label":"Команда"},{"id":"faq","label":"FAQ (часто задаваемые вопросы)"},{"id":"contacts","label":"Контакты"}]'></div>
 
   <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
 

--- a/reverse-additive.html
+++ b/reverse-additive.html
@@ -31,11 +31,12 @@
       <nav class="mb-12" aria-label="Навигация по странице">
         <div class="flex items-center justify-between gap-6">
           <a href="index.html" class="flex items-center gap-3 font-semibold">
-            <svg viewBox="0 0 64 64" class="h-8 w-8" aria-hidden>
+            <svg viewBox="0 0 64 64" class="h-12 w-12" aria-hidden>
               <defs><linearGradient id="logo" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0ea5e9"/><stop offset="1" stop-color="#22c55e"/></linearGradient></defs>
               <rect x="6" y="6" width="52" height="52" rx="12" fill="url(#logo)"/>
               <path d="M20 44V20l12-6 12 6v24l-12 6-12-6z M32 14v36" stroke="#fff" stroke-width="2" fill="none"/>
             </svg>
+            <img src="Logo.svg" alt="Логотип FabLabs R22" class="h-10 w-auto">
             Step3D.Lab
           </a>
           <div class="hidden md:flex items-center gap-1" id="links"></div>


### PR DESCRIPTION
## Summary
- rename the main page branding to "Лаборатория 3D-технологий" and update the equipment section headline to highlight FabLabs R22
- enlarge the Step3D.Lab icon and display the accompanying FabLabs R22 logo in the headers
- add the FabLabs R22 SVG asset for use across the site

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d518762de88333ae297a648421a18d