### PR TITLE
Refactor shared header styles into reusable stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 
   <meta name="description" content="CAD/CAE, реверсивный инжиниринг, 3D‑сканирование, аддитивное производство. Курсы ДПО, проекты, услуги технопарка РГСУ." />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><rect x='6' y='6' width='52' height='52' rx='12' fill='%230ea5e9'/><path d='M20 44V20l12-6 12 6v24l-12 6-12-6z M32 14v36' stroke='%23fff' stroke-width='2' fill='none'/></svg>">
+  <link rel="stylesheet" href="styles/site.css">
   <!-- Tailwind (CDN, удобно для GitHub Pages). Для продакшна соберите локально. -->
   <script src="https://cdn.tailwindcss.com"></script>
 
@@ -20,123 +21,6 @@
     .glass { backdrop-filter: blur(8px) }
     .active-link { background: rgb(15 23 42); color: white }
     .dark .active-link { background: white; color: rgb(15 23 42) }
-
-    /* Хедер в стилистике NotebookLM */
-    .site-topnav {
-      background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(226, 232, 240, 0.88));
-      backdrop-filter: blur(18px);
-      border-bottom: 1px solid rgba(148, 163, 184, 0.22);
-      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
-    }
-    .dark .site-topnav {
-      background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.88));
-      border-bottom-color: rgba(71, 85, 105, 0.55);
-      box-shadow: 0 18px 40px rgba(2, 6, 23, 0.6);
-    }
-    .site-topnav__inner {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 1.75rem;
-      min-height: 72px;
-    }
-    .site-brand {
-      display: inline-flex;
-      align-items: center;
-      gap: 1rem;
-      text-decoration: none;
-      font-weight: 700;
-      letter-spacing: -0.01em;
-      color: inherit;
-    }
-    .site-brand__mark {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      padding: 0.35rem 0.9rem;
-      border-radius: 999px;
-      border: 1px solid rgba(148, 163, 184, 0.32);
-      background: linear-gradient(135deg, rgba(14, 165, 233, 0.12), rgba(34, 197, 94, 0.12));
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
-    }
-    .site-brand__mark img {
-      display: block;
-      width: 120px;
-      height: 28px;
-      object-fit: contain;
-      filter: drop-shadow(0 8px 18px rgba(14, 165, 233, 0.35));
-    }
-    .dark .site-brand__mark {
-      background: linear-gradient(135deg, rgba(15, 118, 110, 0.22), rgba(37, 99, 235, 0.2));
-      border-color: rgba(148, 163, 184, 0.38);
-    }
-    .site-brand__name {
-      display: flex;
-      flex-direction: column;
-      line-height: 1.1;
-      font-size: 1rem;
-    }
-    .site-brand__title { font-size: 1.05rem; }
-    .site-brand__tagline {
-      font-size: 0.72rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.16em;
-      color: rgb(71 85 105);
-    }
-    .dark .site-brand__tagline { color: rgba(226, 232, 240, 0.76); }
-    .site-cta {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      border-radius: 999px;
-      padding: 0.55rem 1.25rem;
-      font-weight: 600;
-      font-size: 0.92rem;
-      color: white;
-      background: linear-gradient(135deg, #0ea5e9, #22c55e);
-      box-shadow: 0 14px 32px rgba(14, 165, 233, 0.3);
-      transition: transform 0.18s ease, box-shadow 0.18s ease;
-    }
-    .site-cta--nav { white-space: nowrap; }
-    .site-cta:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 18px 36px rgba(14, 165, 233, 0.38);
-    }
-    .site-cta:focus-visible {
-      outline: 3px solid rgba(56, 189, 248, 0.6);
-      outline-offset: 3px;
-    }
-    .site-toggle {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 40px;
-      height: 40px;
-      border-radius: 14px;
-      border: 1px solid rgba(148, 163, 184, 0.4);
-      background: rgba(255, 255, 255, 0.65);
-      transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-    }
-    .site-toggle:hover {
-      border-color: rgba(14, 165, 233, 0.6);
-      box-shadow: 0 8px 18px rgba(14, 165, 233, 0.25);
-      transform: translateY(-1px);
-    }
-    .site-toggle:focus-visible {
-      outline: 3px solid rgba(56, 189, 248, 0.55);
-      outline-offset: 3px;
-    }
-    .dark .site-toggle {
-      background: rgba(15, 23, 42, 0.6);
-      border-color: rgba(71, 85, 105, 0.55);
-    }
-    @media (max-width: 768px) {
-      .site-topnav__inner { min-height: 64px; gap: 1rem; }
-      .site-brand__name { display: none; }
-      .site-brand__mark img { width: 96px; }
-      .site-cta--nav { display: none; }
-    }
 
     /* Hero: «космические захватчики» */
     #invaders-hero {

--- a/reverse-additive.html
+++ b/reverse-additive.html
@@ -6,6 +6,7 @@
   <title>Step3D.Lab — Курс «ДПО R22.AM „Реверсивный инжиниринг и аддитивное производство“»</title>
   <meta name="description" content="Практический курс ДПО R22.AM по реверсивному инжинирингу и аддитивному производству: 3D-сканирование, CAD, 3D-печать, календарно-тематический план и команда преподавателей технопарка РГСУ." />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><rect x='6' y='6' width='52' height='52' rx='12' fill='%230ea5e9'/><path d='M20 44V20l12-6 12 6v24l-12 6-12-6z M32 14v36' stroke='%23fff' stroke-width='2' fill='none'/></svg>">
+  <link rel="stylesheet" href="styles/site.css">
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = { theme: { extend: { boxShadow: { soft: '0 6px 30px rgba(15,23,42,.08)' } } } }
@@ -17,116 +18,6 @@
     .active-link { background: rgb(15 23 42); color: white }
     .dark .active-link { background: white; color: rgb(15 23 42) }
 
-    /* Универсальная шапка */
-    .site-topnav {
-      background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(226, 232, 240, 0.88));
-      backdrop-filter: blur(18px);
-      border-bottom: 1px solid rgba(148, 163, 184, 0.22);
-      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
-    }
-    .dark .site-topnav {
-      background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.88));
-      border-bottom-color: rgba(71, 85, 105, 0.55);
-      box-shadow: 0 18px 40px rgba(2, 6, 23, 0.6);
-    }
-    .site-topnav__inner {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 1.75rem;
-      min-height: 72px;
-    }
-    .site-brand {
-      display: inline-flex;
-      align-items: center;
-      gap: 1rem;
-      text-decoration: none;
-      font-weight: 700;
-      letter-spacing: -0.01em;
-      color: inherit;
-    }
-    .site-brand__mark {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      padding: 0.35rem 0.9rem;
-      border-radius: 999px;
-      border: 1px solid rgba(148, 163, 184, 0.32);
-      background: linear-gradient(135deg, rgba(14, 165, 233, 0.12), rgba(34, 197, 94, 0.12));
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
-    }
-    .site-brand__mark img {
-      display: block;
-      width: 120px;
-      height: 28px;
-      object-fit: contain;
-      filter: drop-shadow(0 8px 18px rgba(14, 165, 233, 0.35));
-    }
-    .dark .site-brand__mark {
-      background: linear-gradient(135deg, rgba(15, 118, 110, 0.22), rgba(37, 99, 235, 0.2));
-      border-color: rgba(148, 163, 184, 0.38);
-    }
-    .site-brand__name {
-      display: flex;
-      flex-direction: column;
-      line-height: 1.1;
-      font-size: 1rem;
-    }
-    .site-brand__title { font-size: 1.05rem; }
-    .site-brand__tagline {
-      font-size: 0.72rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.16em;
-      color: rgb(71 85 105);
-    }
-    .dark .site-brand__tagline { color: rgba(226, 232, 240, 0.76); }
-    .site-cta {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      border-radius: 999px;
-      padding: 0.55rem 1.25rem;
-      font-weight: 600;
-      font-size: 0.92rem;
-      color: white;
-      background: linear-gradient(135deg, #0ea5e9, #22c55e);
-      box-shadow: 0 14px 32px rgba(14, 165, 233, 0.3);
-      transition: transform 0.18s ease, box-shadow 0.18s ease;
-    }
-    .site-cta--nav { white-space: nowrap; }
-    .site-cta:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 18px 36px rgba(14, 165, 233, 0.38);
-    }
-    .site-cta:focus-visible {
-      outline: 3px solid rgba(56, 189, 248, 0.6);
-      outline-offset: 3px;
-    }
-    .site-toggle {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 40px;
-      height: 40px;
-      border-radius: 14px;
-      border: 1px solid rgba(148, 163, 184, 0.4);
-      background: rgba(255, 255, 255, 0.65);
-      transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-    }
-    .site-toggle:hover {
-      border-color: rgba(14, 165, 233, 0.6);
-      box-shadow: 0 8px 18px rgba(14, 165, 233, 0.25);
-      transform: translateY(-1px);
-    }
-    .site-toggle:focus-visible {
-      outline: 3px solid rgba(56, 189, 248, 0.55);
-      outline-offset: 3px;
-    }
-    .dark .site-toggle {
-      background: rgba(15, 23, 42, 0.6);
-      border-color: rgba(71, 85, 105, 0.55);
-    }
     #mobileMenu[data-open='true'] [data-menu-overlay] {
       opacity: 1;
     }
@@ -138,12 +29,6 @@
       #mobileMenu .menu-panel {
         transition: none !important;
       }
-    }
-    @media (max-width: 768px) {
-      .site-topnav__inner { min-height: 64px; gap: 1rem; }
-      .site-brand__name { display: none; }
-      .site-brand__mark img { width: 96px; }
-      .site-cta--nav { display: none; }
     }
   </style>
 </head>

--- a/styles/site.css
+++ b/styles/site.css
@@ -1,0 +1,153 @@
+/* Shared site header styles */
+.site-topnav {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(226, 232, 240, 0.88));
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.22);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+}
+
+.dark .site-topnav {
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.88));
+  border-bottom-color: rgba(71, 85, 105, 0.55);
+  box-shadow: 0 18px 40px rgba(2, 6, 23, 0.6);
+}
+
+.site-topnav__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.75rem;
+  min-height: 72px;
+}
+
+.site-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 1rem;
+  text-decoration: none;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: inherit;
+}
+
+.site-brand__mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.12), rgba(34, 197, 94, 0.12));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+.site-brand__mark img {
+  display: block;
+  width: 120px;
+  height: 28px;
+  object-fit: contain;
+  filter: drop-shadow(0 8px 18px rgba(14, 165, 233, 0.35));
+}
+
+.dark .site-brand__mark {
+  background: linear-gradient(135deg, rgba(15, 118, 110, 0.22), rgba(37, 99, 235, 0.2));
+  border-color: rgba(148, 163, 184, 0.38);
+}
+
+.site-brand__name {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+  font-size: 1rem;
+}
+
+.site-brand__title {
+  font-size: 1.05rem;
+}
+
+.site-brand__tagline {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: rgb(71 85 105);
+}
+
+.dark .site-brand__tagline {
+  color: rgba(226, 232, 240, 0.76);
+}
+
+.site-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  padding: 0.55rem 1.25rem;
+  font-weight: 600;
+  font-size: 0.92rem;
+  color: white;
+  background: linear-gradient(135deg, #0ea5e9, #22c55e);
+  box-shadow: 0 14px 32px rgba(14, 165, 233, 0.3);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.site-cta--nav {
+  white-space: nowrap;
+}
+
+.site-cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 36px rgba(14, 165, 233, 0.38);
+}
+
+.site-cta:focus-visible {
+  outline: 3px solid rgba(56, 189, 248, 0.6);
+  outline-offset: 3px;
+}
+
+.site-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(255, 255, 255, 0.65);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.site-toggle:hover {
+  border-color: rgba(14, 165, 233, 0.6);
+  box-shadow: 0 8px 18px rgba(14, 165, 233, 0.25);
+  transform: translateY(-1px);
+}
+
+.site-toggle:focus-visible {
+  outline: 3px solid rgba(56, 189, 248, 0.55);
+  outline-offset: 3px;
+}
+
+.dark .site-toggle {
+  background: rgba(15, 23, 42, 0.6);
+  border-color: rgba(71, 85, 105, 0.55);
+}
+
+@media (max-width: 768px) {
+  .site-topnav__inner {
+    min-height: 64px;
+    gap: 1rem;
+  }
+
+  .site-brand__name {
+    display: none;
+  }
+
+  .site-brand__mark img {
+    width: 96px;
+  }
+
+  .site-cta--nav {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- move the shared navigation, brand, CTA, and toggle styles into styles/site.css
- link the shared stylesheet from both HTML pages and keep only page-specific rules inline
- retain the mobile menu transition rules on the course page after removing duplicates

## Testing
- Manual desktop and mobile verification via local http-server

------
https://chatgpt.com/codex/tasks/task_e_68d6a359f6c483338af45714228a8614