### PR TITLE
Update FabLab network content and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -689,26 +689,23 @@
     </div>
   </section>
 
-  <!-- FabLabs R22 - распределенная сеть 3D-печати -->
+  <!-- Распределенная сеть 3D-печати -->
   <section id="equipment" class="py-16 md:py-24 bg-white dark:bg-slate-900">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <h2 class="text-3xl md:text-4xl font-bold mb-6">FabLabs R22 - распределенная сеть 3D-печати</h2>
-      <p class="text-slate-600 dark:text-slate-300 max-w-3xl">3D‑сканеры RangeVision и Artec; принтеры FDM/DLP (Ultimaker, Picaso 3D, Formlabs); лазер Trotec, фрезерные Roland; GenAI и open-source инструменты: Perplexity AI, Qwen, Blender, FreeCAD, OpenSCAD, Hugging Face, T‑FLEX CAD.</p>
+      <h2 class="text-3xl md:text-4xl font-bold mb-6">Распределенная сеть 3D-печати</h2>
+      <p class="text-slate-600 dark:text-slate-300 max-w-3xl">Экспериментальный проект технопарка РГСУ для слушателей программ ДПО и студентов университета: учимся проектировать, печатать и запускать инженерные кейсы в FabLab-формате.</p>
       <div class="mt-6 grid lg:grid-cols-2 gap-8">
         <div class="rounded-3xl border border-slate-200 dark:border-slate-700 p-4">
-          <h3 class="text-lg font-semibold mb-3">3D‑сканеры</h3>
+          <h3 class="text-lg font-semibold mb-3">3D‑принтеры · FDM</h3>
           <ul class="grid sm:grid-cols-2 gap-3">
-            <li class="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 flex items-center justify-between"><span class="font-medium">RangeVision NEO</span><span class="text-sm text-slate-500">1 шт.</span></li>
-            <li class="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 flex items-center justify-between"><span class="font-medium">Artec Eva + Spider (ручной)</span><span class="text-sm text-slate-500">2 шт.</span></li>
-            <li class="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 flex items-center justify-between"><span class="font-medium">Архитектурный сканер Leica</span><span class="text-sm text-slate-500">1 шт.</span></li>
+            <li class="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 flex items-center justify-between"><span class="font-medium">Ultimaker 3</span><span class="text-sm text-slate-500">—</span></li>
+            <li class="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 flex items-center justify-between"><span class="font-medium">Picaso 3D Designer X</span><span class="text-sm text-slate-500">—</span></li>
           </ul>
         </div>
         <div class="rounded-3xl border border-slate-200 dark:border-slate-700 p-4">
-          <h3 class="text-lg font-semibold mb-3">3D‑принтеры</h3>
+          <h3 class="text-lg font-semibold mb-3">3D‑принтеры · DLP/SLA</h3>
           <ul class="grid sm:grid-cols-2 gap-3">
-            <li class="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 flex items-center justify-between"><span class="font-medium">Ultimaker 3 (FDM)</span><span class="text-sm text-slate-500">—</span></li>
-            <li class="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 flex items-center justify-between"><span class="font-medium">Picaso 3D Designer X (FDM)</span><span class="text-sm text-slate-500">—</span></li>
-            <li class="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 flex items-center justify-between"><span class="font-medium">Formlabs (DLP/SLA)</span><span class="text-sm text-slate-500">—</span></li>
+            <li class="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 flex items-center justify-between"><span class="font-medium">Formlabs</span><span class="text-sm text-slate-500">—</span></li>
           </ul>
         </div>
         <div class="relative overflow-hidden rounded-3xl border border-slate-200/70 bg-gradient-to-br from-white/80 via-sky-50/60 to-slate-50/90 p-6 lg:p-8 shadow-soft dark:border-slate-700/70 dark:from-slate-900/80 dark:via-slate-900/70 dark:to-slate-800/80">
@@ -908,122 +905,12 @@
               <a href="https://tflex.ru/products/cad/" class="font-medium text-slate-900 dark:text-slate-100 hover:text-sky-600 dark:hover:text-sky-400" target="_blank" rel="noopener">T‑FLEX CAD</a>
               <p class="text-sm text-slate-500 dark:text-slate-300">Профессиональный параметрический CAD российского производства.</p>
             </li>
+            <li class="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 flex flex-col gap-1">
+              <a href="https://notebooklm.google/" class="font-medium text-slate-900 dark:text-slate-100 hover:text-sky-600 dark:hover:text-sky-400" target="_blank" rel="noopener">NotebookLM</a>
+              <p class="text-sm text-slate-500 dark:text-slate-300">Сервис Google для генерации заметок и исследований на основе ваших источников.</p>
+            </li>
           </ul>
         </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Проекты и НИР -->
-  <section id="projects" class="py-16 md:py-24">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <h2 class="text-3xl md:text-4xl font-bold mb-6">Проекты и направления НИР</h2>
-      <div class="grid md:grid-cols-2 gap-6 md:gap-8">
-        <!-- Карточка проекта с мини-слайдером (ванильный JS) -->
-        <article class="project-card js-gallery" data-index="0">
-          <div class="project-card__body">
-            <div class="space-y-4">
-              <div class="project-card__headline">
-                <span class="project-card__icon" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M12 3v18"/>
-                    <path d="M6 9h12"/>
-                    <path d="M5 15h14" opacity="0.6"/>
-                    <path d="M9 21h6" opacity="0.4"/>
-                  </svg>
-                </span>
-                <div>
-                  <p class="project-card__eyebrow">Проекты · MedTech</p>
-                  <h3 class="text-xl font-semibold leading-snug">Изготовление ортезов и протезов</h3>
-                </div>
-              </div>
-              <p class="text-slate-600 dark:text-slate-300 text-sm md:text-base">Индивидуальные ортезы и протезы полного цикла: от 3D‑сканирования и проектирования до печати, постобработки и примерки.</p>
-              <div class="project-card__tags">
-                <span>MedTech</span>
-                <span>FDM/DLP</span>
-                <span>CAD→Print</span>
-              </div>
-              <div class="project-card__meta">
-                <svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M12 6v6l3 3"/>
-                  <circle cx="12" cy="12" r="9"/>
-                </svg>
-                <span>Срок изготовления 5–7 дней: проект ведётся инженером-наставником, команда проходит все этапы от анализа до тестов.</span>
-              </div>
-            </div>
-            <div class="project-card__media">
-              <div class="project-card__slider">
-                <div class="aspect-video">
-                  <div class="slide">Сканирование пациента · этап 1</div>
-                  <div class="slide hidden">CAD-модель и топология · этап 2</div>
-                  <div class="slide hidden">Печать и примерка изделия · этап 3</div>
-                </div>
-                <div class="project-card__controls">
-                  <button class="gallery-nav js-prev" aria-label="Предыдущий слайд">
-                    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15.5 4.5 8 12l7.5 7.5Z"/></svg>
-                  </button>
-                  <div class="js-dots"></div>
-                  <button class="gallery-nav js-next" aria-label="Следующий слайд">
-                    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8.5 4.5 7.5 7.5-7.5 7.5Z"/></svg>
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </article>
-        <article class="project-card js-gallery" data-index="0">
-          <div class="project-card__body">
-            <div class="space-y-4">
-              <div class="project-card__headline">
-                <span class="project-card__icon" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M4 7h16l-8 5Z"/>
-                    <path d="M6 12v6l6 3 6-3v-6"/>
-                    <path d="M6 9v-2" opacity="0.5"/>
-                    <path d="M18 9v-2" opacity="0.5"/>
-                  </svg>
-                </span>
-                <div>
-                  <p class="project-card__eyebrow">Проекты · Heritage</p>
-                  <h3 class="text-xl font-semibold leading-snug">Оцифровка объектов культурного наследия</h3>
-                </div>
-              </div>
-              <p class="text-slate-600 dark:text-slate-300 text-sm md:text-base">Высокоточная съёмка архитектуры и экспонатов, реконструкция геометрии, подготовка интерактивных и выставочных макетов.</p>
-              <div class="project-card__tags">
-                <span>3D Scan</span>
-                <span>Photogrammetry</span>
-                <span>XR-ready</span>
-              </div>
-              <div class="project-card__meta">
-                <svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M3 6h18"/>
-                  <path d="M7 6v12"/>
-                  <path d="M17 6v12"/>
-                  <path d="M4 18h16"/>
-                </svg>
-                <span>Формируем цифровые двойники и каталоги: данные передаются музеям и проектным бюро в согласованных форматах.</span>
-              </div>
-            </div>
-            <div class="project-card__media">
-              <div class="project-card__slider">
-                <div class="aspect-video">
-                  <div class="slide">Лазерное сканирование фасада · сцена 1</div>
-                  <div class="slide hidden">Обработка облака точек · сцена 2</div>
-                  <div class="slide hidden">Презентация VR/AR макета · сцена 3</div>
-                </div>
-                <div class="project-card__controls">
-                  <button class="gallery-nav js-prev" aria-label="Предыдущий слайд">
-                    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15.5 4.5 8 12l7.5 7.5Z"/></svg>
-                  </button>
-                  <div class="js-dots"></div>
-                  <button class="gallery-nav js-next" aria-label="Следующий слайд">
-                    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8.5 4.5 7.5 7.5-7.5 7.5Z"/></svg>
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </article>
       </div>
     </div>
   </section>
@@ -1203,7 +1090,7 @@
         <div class="grid sm:grid-cols-2 md:grid-cols-4 gap-8">
           <div><div class="text-sm font-semibold mb-3">Продукты</div><ul class="space-y-2 text-sm"><li><a href="#services" class="hover:underline">CAD/CAE‑моделирование</a></li><li><a href="#services" class="hover:underline">Реверсивный инжиниринг</a></li><li><a href="#services" class="hover:underline">Аддитивное производство</a></li><li><a href="#services" class="hover:underline">Прототипирование</a></li></ul></div>
           <div><div class="text-sm font-semibold mb-3">Образование</div><ul class="space-y-2 text-sm"><li><a href="#courses" class="hover:underline">Курсы ДПО</a></li><li><a href="#courses" class="hover:underline">Проектные школы</a></li><li><a href="#courses" class="hover:underline">Силлабусы</a></li><li><a href="#contacts" class="hover:underline">Заявка на обучение</a></li></ul></div>
-          <div><div class="text-sm font-semibold mb-3">Проекты</div><ul class="space-y-2 text-sm"><li><a href="#projects" class="hover:underline">MedTech</a></li><li><a href="#projects" class="hover:underline">Robotics</a></li><li><a href="#projects" class="hover:underline">Reverse engineering</a></li><li><a href="#projects" class="hover:underline">Design & Render</a></li></ul></div>
+          <div><div class="text-sm font-semibold mb-3">Сеть 3D-печати</div><ul class="space-y-2 text-sm"><li><a href="#equipment" class="hover:underline">FDM‑принтеры</a></li><li><a href="#equipment" class="hover:underline">DLP/SLA‑принтеры</a></li><li><a href="#equipment" class="hover:underline">GenAI + Open Source</a></li><li><a href="#equipment" class="hover:underline">Экспресс-калькулятор</a></li></ul></div>
           <div><div class="text-sm font-semibold mb-3">Ресурсы</div><ul class="space-y-2 text-sm"><li><a href="#" class="hover:underline">Методические материалы</a></li><li><a href="#" class="hover:underline">3D‑модели (STP)</a></li><li><a href="#" class="hover:underline">Политика данных</a></li><li><a href="#" class="hover:underline">Блог</a></li></ul></div>
         </div>
         <div class="mt-10 flex flex-wrap items-center justify-between gap-4 text-xs text-slate-500 dark:text-slate-400">
@@ -1246,7 +1133,7 @@
   </div>
 
   <!-- Секции для навигации (для автоподсветки) -->
-  <div id="nav-data" class="hidden" data-nav='[{"id":"services","label":"Возможности"},{"id":"equipment","label":"FabLabs R22"},{"id":"projects","label":"Проекты"},{"id":"courses","label":"Обучение"},{"id":"team","label":"Команда"},{"id":"faq","label":"FAQ (часто задаваемые вопросы)"},{"id":"contacts","label":"Контакты"}]'></div>
+  <div id="nav-data" class="hidden" data-nav='[{"id":"services","label":"Возможности"},{"id":"equipment","label":"Сеть 3D-печати"},{"id":"courses","label":"Обучение"},{"id":"team","label":"Команда"},{"id":"faq","label":"FAQ (часто задаваемые вопросы)"},{"id":"contacts","label":"Контакты"}]'></div>
 
   <script>
     function initInvaders(THREE, { canvas, section }) {


### PR DESCRIPTION
## Summary
- rename the FabLabs block to "Распределенная сеть 3D-печати", split the printers list into separate FDM and DLP/SLA sections, and add a fablab description
- remove the outdated "Проекты и направления НИР" section and align navigation/footer labels with the updated equipment section
- extend the GenAI + Open Source resources with a NotebookLM link

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6ada0827c83339a36448841275e7f