### PR TITLE
Remove share link button and course chips

### DIFF
--- a/index.html
+++ b/index.html
@@ -797,11 +797,7 @@
           <h2 class="text-3xl md:text-4xl font-bold leading-tight text-slate-900 dark:text-white">Обучение и мастер-классы</h2>
           <p class="text-base md:text-lg text-slate-600 dark:text-slate-300">Погружение в CAD/CAE, 3D‑сканирование, аддитивное производство и промышленный дизайн — от интенсивов для школьников до профессионального дополнительного образования.</p>
         </div>
-        <div class="flex flex-wrap gap-3 text-sm">
-          <span class="chip-feature">Очные и гибридные форматы</span>
-          <span class="chip-feature">Менторская поддержка экспертов</span>
-          <span class="chip-feature">Портфолио и промышленная практика</span>
-        </div>
+        
       </div>
       <div class="mt-10 grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)] xl:gap-10">
         <div class="course-card" data-status="closed">
@@ -970,10 +966,6 @@
               <svg viewBox="0 0 24 24" class="h-5 w-5" aria-hidden><path d="M4 6h16a1 1 0 011 1v10a1 1 0 01-1 1H4a1 1 0 01-1-1V7a1 1 0 011-1zm0 0l8 6 8-6" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path d="M5 18l5.5-4.125" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path d="M19 18l-5.5-4.125" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
               projects.step3d@gmail.com
             </a>
-            <button id="shareLink" class="inline-flex items-center gap-2 rounded-xl bg-white dark:bg-slate-800 px-5 py-3 border border-slate-200 dark:border-slate-700 font-medium shadow-sm" aria-label="Поделиться ссылкой">
-              <svg viewBox="0 0 24 24" class="h-5 w-5"><path d="M8.59 13.51l6.83 3.91m-6.83-7.83l6.83-3.91M18 8a3 3 0 10-3-3m3 14a3 3 0 10-3-3m-9 3a3 3 0 100-6" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
-              <span class="sr-only">Поделиться ссылкой</span>
-            </button>
           </div>
         </div>
         <div class="rounded-3xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-soft">


### PR DESCRIPTION
## Summary
- remove the share-link icon button from the contacts section
- delete the course highlight chips under the education heading

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d799cf7450833393060df83c497152