### PR TITLE
Remove 4DI.01 course from training section

### DIFF
--- a/index.html
+++ b/index.html
@@ -800,45 +800,6 @@
         
       </div>
       <div class="mt-10 grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)] xl:gap-10">
-        <div class="course-card" data-status="closed">
-          <div class="course-card__inner">
-            <div class="flex flex-col gap-6">
-              <div class="flex items-start justify-between gap-4">
-                <div class="space-y-4">
-                  <div class="flex flex-wrap items-center gap-3">
-                    <svg viewBox="0 0 64 64" class="h-12 w-12 shrink-0" aria-hidden><defs><linearGradient id="c1" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#facc15"/><stop offset="1" stop-color="#f97316"/></linearGradient></defs><rect x="6" y="6" width="52" height="52" rx="12" fill="url(#c1)"/><path d="M20 44V20l12-6 12 6v24l-12 6-12-6z M32 14v36" stroke="#fff" stroke-width="2" fill="none"/></svg>
-                    <div>
-                      <h3 class="text-xl font-semibold leading-tight text-slate-900 dark:text-slate-100">4DI.01 «Промышленный дизайн и инжиниринг»</h3>
-                      <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">Модульная программа с практикой в лабораториях технопарка</p>
-                    </div>
-                  </div>
-                  <p class="text-base text-slate-600 dark:text-slate-300">CAD, прототипирование, аддитивные технологии</p>
-                  <div class="flex flex-wrap gap-2 text-xs sm:text-sm text-slate-600 dark:text-slate-300">
-                    <span class="badge-accent">Бесплатно · грант ДОиН г. Москвы «Инженерный класс»</span>
-                    <span class="badge-neutral">72 ч</span>
-                    <span class="badge-neutral">7–11 класс, студенты</span>
-                  </div>
-                </div>
-                <span class="status-pill status-pill--closed">Набор закрыт</span>
-              </div>
-              <div class="space-y-4 text-sm text-slate-600 dark:text-slate-300">
-                <div class="grid gap-2 sm:flex sm:flex-wrap sm:items-center sm:gap-3">
-                  <span class="badge-soft badge-soft--amber">Старт 8 сентября 2025</span>
-                  <span class="badge-soft badge-soft--amber">Финиш 22 декабря 2025</span>
-                </div>
-                <div>
-                  <div class="inline-flex items-center gap-2 rounded-xl border border-slate-200/80 bg-white/80 px-3 py-1.5 font-medium text-slate-700 shadow-sm dark:border-slate-600/60 dark:bg-slate-800/70 dark:text-slate-100">
-                    <svg viewBox="0 0 20 20" class="h-4 w-4" aria-hidden><path d="M4 4.75A1.75 1.75 0 0 1 5.75 3h8.5A1.75 1.75 0 0 1 16 4.75v10.5A1.75 1.75 0 0 1 14.25 17h-8.5A1.75 1.75 0 0 1 4 15.25ZM5.75 4.5a.25.25 0 0 0-.25.25v10.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25V4.75a.25.25 0 0 0-.25-.25Z" fill="currentColor"/></svg>
-                    Группа укомплектована · 22 / 22 участников
-                  </div>
-                  <div class="course-progress mt-3" aria-hidden>
-                    <span style="width: 100%"></span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
         <a class="course-card group focus:outline-none focus-visible:ring-4 focus-visible:ring-sky-300/70 dark:focus-visible:ring-sky-500/40" href="reverse-additive.html">
           <div class="course-card__inner">
             <div class="flex flex-col gap-6">


### PR DESCRIPTION
## Summary
- remove the 4DI.01 «Промышленный дизайн и инжиниринг» card from the courses grid on the homepage

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d79ba6e24c833387905fb5e858b5f2