### PR TITLE
Add hero headline for Step3D.Lab

### DIFF
--- a/index.html
+++ b/index.html
@@ -537,16 +537,19 @@
         <!-- Hero -->
         <div class="grid md:grid-cols-2 gap-10 md:gap-16 items-center" id="top">
           <div>
-
-          <p class="mt-4 text-lg text-slate-600 dark:text-slate-300 max-w-prose">Инженерный центр Step3D.Lab: цифровое проектирование, реверсивный инжиниринг, 3D‑сканирование и аддитивное производство. Команда технопарка РГСУ и ООО «СТЕП 3Д» выполняет разработки, сопровождает внедрение и обучает специалистов.</p>
-          <div class="mt-6 flex flex-wrap gap-3">
-            <button id="openModal" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-5 py-3 text-white font-medium shadow hover:bg-slate-800 focus:outline-none focus:ring-4 focus:ring-slate-300">Оставить заявку</button>
-            <button type="button" id="toggleAbout" class="about-toggle inline-flex items-center gap-2 rounded-xl border border-slate-300/80 dark:border-slate-600 px-5 py-3 font-medium transition" aria-controls="aboutBox" aria-expanded="false" data-label-open="О лаборатории" data-label-close="Свернуть описание">О лаборатории</button>
-          </div>
-          <div id="aboutBox" class="about-box glass" data-open="false" tabindex="-1" aria-hidden="true" role="region" aria-labelledby="toggleAbout">
-            <div class="about-box__content" data-about-inner>
-              <h3 class="text-xl font-semibold mb-2">О лаборатории</h3>
-              <p class="text-slate-700 dark:text-slate-300">Step3D.Lab — команда инженеров, дизайнеров и преподавателей. Работаем на базе технопарка РГСУ совместно с ООО «СТЕП 3Д»: выполняем R&amp;D‑проекты, проводим курсы ДПО (48–72 ч), сопровождаем производственные задачи и студенческие инициативы. Фокус — CAD/CAE, реверсивный инжиниринг, 3D‑сканирование, прототипирование и аддитивное производство.</p>
+            <h1 class="text-4xl md:text-5xl font-bold leading-tight text-slate-900 dark:text-white">
+              Step3D.Lab — цифровая лаборатория инженерии и аддитивного производства
+            </h1>
+            <p class="mt-4 text-lg text-slate-600 dark:text-slate-300 max-w-prose">Инженерный центр Step3D.Lab: цифровое проектирование, реверсивный инжиниринг, 3D‑сканирование и аддитивное производство. Команда технопарка РГСУ и ООО «СТЕП 3Д» выполняет разработки, сопровождает внедрение и обучает специалистов.</p>
+            <div class="mt-6 flex flex-wrap gap-3">
+              <button id="openModal" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-5 py-3 text-white font-medium shadow hover:bg-slate-800 focus:outline-none focus:ring-4 focus:ring-slate-300">Оставить заявку</button>
+              <button type="button" id="toggleAbout" class="about-toggle inline-flex items-center gap-2 rounded-xl border border-slate-300/80 dark:border-slate-600 px-5 py-3 font-medium transition" aria-controls="aboutBox" aria-expanded="false" data-label-open="О лаборатории" data-label-close="Свернуть описание">О лаборатории</button>
+            </div>
+            <div id="aboutBox" class="about-box glass" data-open="false" tabindex="-1" aria-hidden="true" role="region" aria-labelledby="toggleAbout">
+              <div class="about-box__content" data-about-inner>
+                <h2 class="text-xl font-semibold mb-2">О лаборатории</h2>
+                <p class="text-slate-700 dark:text-slate-300">Step3D.Lab — команда инженеров, дизайнеров и преподавателей. Работаем на базе технопарка РГСУ совместно с ООО «СТЕП 3Д»: выполняем R&amp;D‑проекты, проводим курсы ДПО (48–72 ч), сопровождаем производственные задачи и студенческие инициативы. Фокус — CAD/CAE, реверсивный инжиниринг, 3D‑сканирование, прототипирование и аддитивное производство.</p>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add a hero section H1 headline that introduces Step3D.Lab with existing utility classes
- promote the about box heading to H2 to keep heading levels sequential

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d79e8d41a08333914fa3eda8b9d339