### PR TITLE
Add modal close handlers for backdrop and cancel button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1855,6 +1855,13 @@
 
     document.getElementById('openModal')?.addEventListener('click', openModal)
     document.getElementById('openModal2')?.addEventListener('click', openModal)
+    modalCloseBtn?.addEventListener('click', closeModal)
+    modalBg?.addEventListener('click', closeModal)
+    modal?.addEventListener('click', event => {
+      if(event.target === modal){
+        closeModal()
+      }
+    })
 
 
     // ===== «О лаборатории» toggle


### PR DESCRIPTION
## Summary
- add modal close handlers for the cancel button and backdrop
- close the modal when clicking the outer container

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7a58e18108333bab6c837caf74aea