### PR TITLE
Add main landmark and skip link to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -489,6 +489,7 @@
   </script>
 </head>
 <body class="min-h-screen bg-gradient-to-b from-white to-slate-50 text-slate-800 dark:from-slate-900 dark:to-slate-950 dark:text-slate-100">
+  <a class="skip-link" href="#main">Перейти к основному содержимому</a>
   <!-- Прогресс-бар прокрутки -->
   <div id="progress" class="fixed top-0 left-0 h-1 bg-slate-900/90 origin-left z-50" style="transform:scaleX(0);transform-origin:left"></div>
 
@@ -567,6 +568,7 @@
     </div>
   </header>
 
+  <main id="main" tabindex="-1">
   <!-- Возможности -->
   <section id="services" class="py-16 md:py-24">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -909,6 +911,8 @@
       </div>
     </div>
   </section>
+
+  </main>
 
   <!-- Контакты + карта -->
   <footer id="contacts" class="py-16 md:py-24 border-t border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">

--- a/styles/site.css
+++ b/styles/site.css
@@ -6,6 +6,29 @@
   box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
 }
 
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.skip-link:focus {
+  position: fixed;
+  left: 1rem;
+  top: 1rem;
+  width: auto;
+  height: auto;
+  padding: 0.75rem 1.25rem;
+  background: linear-gradient(135deg, #0ea5e9, #22c55e);
+  color: #fff;
+  border-radius: 999px;
+  z-index: 1000;
+  box-shadow: 0 16px 32px rgba(14, 165, 233, 0.35);
+}
+
 .dark .site-topnav {
   background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.88));
   border-bottom-color: rgba(71, 85, 105, 0.55);


### PR DESCRIPTION
## Summary
- add a skip link before the page header that targets the new main landmark
- wrap the primary sections (services, equipment, courses, team, faq) inside <main id="main">
- ensure the skip link is styled in the site stylesheet so it only appears when focused

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7a58611cc83338586bea54df1bf59