### PR TITLE
Add countdown banner and mentor section to landing page

### DIFF
--- a/app.js
+++ b/app.js
@@ -77,6 +77,32 @@ const formatDateHuman = (iso) => {
     });
 };
 
+const formatDateFull = (iso) => {
+    const date = new Date(iso);
+    const datePart = date.toLocaleDateString("ru-RU", {
+        day: "numeric",
+        month: "long"
+    });
+    const timePart = date.toLocaleTimeString("ru-RU", {
+        hour: "2-digit",
+        minute: "2-digit"
+    });
+    return `${datePart} · ${timePart} (МСК)`;
+};
+
+const formatDateCountdownLabel = (iso) => {
+    const date = new Date(iso);
+    const dayMonth = date.toLocaleDateString("ru-RU", {
+        day: "numeric",
+        month: "long"
+    });
+    const time = date.toLocaleTimeString("ru-RU", {
+        hour: "2-digit",
+        minute: "2-digit"
+    });
+    return `${dayMonth} в ${time}`;
+};
+
 // Состояние приложения. Хранит UTM метки и текущий тариф.
 const state = {
     utm: {
@@ -103,6 +129,7 @@ document.addEventListener("DOMContentLoaded", () => {
     initFaqAccordion();
     initForm();
     initStickyCTA();
+    initCountdown();
     initParticles();
     initAnalyticsObservers();
     injectJsonLd();
@@ -129,6 +156,11 @@ function bindConfigData() {
     const organizerElement = document.querySelector('[data-config-text="organizerName"]');
     if (organizerElement) {
         organizerElement.textContent = "Технопарк РГСУ";
+    }
+
+    const announcementElement = document.querySelector('[data-config-text="eventDateFull"]');
+    if (announcementElement) {
+        announcementElement.textContent = formatDateFull(CONFIG.eventDateISO);
     }
 
     document.querySelectorAll('[data-config-link="email"]').forEach((link) => {
@@ -185,6 +217,64 @@ function bindConfigData() {
     if (stickyPrice) {
         stickyPrice.textContent = formatPrice(CONFIG.priceOnline);
     }
+}
+
+// Отсчет времени до события в верхнем баннере
+function initCountdown() {
+    const countdown = document.querySelector('[data-countdown]');
+    if (!countdown) {
+        return;
+    }
+
+    const valuesWrap = countdown.querySelector('[data-countdown-values]');
+    const daysElement = countdown.querySelector('[data-countdown-days]');
+    const hoursElement = countdown.querySelector('[data-countdown-hours]');
+    const minutesElement = countdown.querySelector('[data-countdown-minutes]');
+    const labelElement = countdown.querySelector('[data-countdown-label]');
+
+    if (!daysElement || !hoursElement || !minutesElement || !labelElement) {
+        return;
+    }
+
+    const eventTimestamp = new Date(CONFIG.eventDateISO).getTime();
+    const labelSuffix = formatDateCountdownLabel(CONFIG.eventDateISO);
+
+    let timerId;
+
+    const update = () => {
+        const now = Date.now();
+        const diff = eventTimestamp - now;
+
+        if (diff <= 0) {
+            labelElement.textContent = "Интенсив уже начался";
+            daysElement.textContent = "00";
+            hoursElement.textContent = "00";
+            minutesElement.textContent = "00";
+            if (valuesWrap) {
+                valuesWrap.setAttribute("data-countdown-ended", "");
+            }
+            if (timerId) {
+                window.clearInterval(timerId);
+            }
+            return;
+        }
+
+        const totalMinutes = Math.floor(diff / 60000);
+        const days = Math.floor(totalMinutes / (24 * 60));
+        const hours = Math.floor((totalMinutes % (24 * 60)) / 60);
+        const minutes = totalMinutes % 60;
+
+        daysElement.textContent = String(days).padStart(2, "0");
+        hoursElement.textContent = String(hours).padStart(2, "0");
+        minutesElement.textContent = String(minutes).padStart(2, "0");
+        labelElement.textContent = `До старта ${labelSuffix}`;
+        if (valuesWrap) {
+            valuesWrap.removeAttribute("data-countdown-ended");
+        }
+    };
+
+    update();
+    timerId = window.setInterval(update, 60000);
 }
 
 // Читаем UTM метки из адресной строки и сохраняем в state.

--- a/index.html
+++ b/index.html
@@ -39,6 +39,24 @@
     <a class="skip-link" href="#main">Перейти к основному содержимому</a>
     <!-- Обертка сайта для управления фоном -->
     <div class="page" data-page>
+        <!-- Верхний анонс с отсчетом времени -->
+        <div class="announcement" data-announcement>
+            <div class="announcement__inner container">
+                <div class="announcement__status">
+                    <span class="announcement__dot" aria-hidden="true"></span>
+                    <span class="announcement__label" data-config-text="eventDateFull">14 декабря в 10:00 (МСК)</span>
+                </div>
+                <div class="announcement__timer" data-countdown>
+                    <span class="announcement__timer-label" data-countdown-label>До старта осталось:</span>
+                    <div class="announcement__timer-values" data-countdown-values>
+                        <span class="announcement__time"><span data-countdown-days>00</span><small>д</small></span>
+                        <span class="announcement__time"><span data-countdown-hours>00</span><small>ч</small></span>
+                        <span class="announcement__time"><span data-countdown-minutes>00</span><small>м</small></span>
+                    </div>
+                </div>
+                <a class="announcement__link" href="#registration" data-scroll data-cta="true" data-href-base="#registration" data-position="announcement" data-tariff="online">Забронировать место</a>
+            </div>
+        </div>
         <!-- Шапка сайта с навигацией и логотипом -->
         <header class="site-header" data-header>
             <div class="container header-inner">
@@ -63,6 +81,7 @@
                     <ul class="nav__list" data-nav-list>
                         <!-- Каждый пункт ведет к секции и участвует в scrollspy -->
                         <li><a class="nav__link" href="#program" data-scroll data-nav-link>Программа</a></li>
+                        <li><a class="nav__link" href="#mentors" data-scroll data-nav-link>Менторы</a></li>
                         <li><a class="nav__link" href="#reviews" data-scroll data-nav-link>Отзывы</a></li>
                         <li><a class="nav__link" href="#pricing" data-scroll data-nav-link>Тарифы</a></li>
                         <li><a class="nav__link" href="#faq" data-scroll data-nav-link>FAQ</a></li>
@@ -257,6 +276,50 @@
                     <div class="program__toggle">
                         <!-- Кнопка для показа дополнительной программы -->
                         <button class="btn btn--ghost" type="button" aria-expanded="false" data-program-toggle>Показать полную программу</button>
+                    </div>
+                </div>
+            </section>
+            <!-- Блок с наставниками -->
+            <section id="mentors" class="section section--panel" data-section="mentors">
+                <div class="container">
+                    <header class="section__header">
+                        <h2 class="section__title">Наставники интенсива</h2>
+                        <p class="section__description">За каждым блоком стоит практик, который внедряет ИИ в реальных компаниях и делится собственными кейсами.</p>
+                    </header>
+                    <div class="mentor-grid">
+                        <article class="mentor-card">
+                            <img class="mentor-card__photo" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='96' height='96'%3E%3Crect width='96' height='96' rx='30' fill='%23eef2ff'/%3E%3Ctext x='48' y='62' font-size='40' text-anchor='middle' fill='%234a6fff'%3EА%3C/text%3E%3C/svg%3E" alt="Фото наставника Антона" width="96" height="96" loading="lazy" decoding="async">
+                            <div class="mentor-card__body">
+                                <h3 class="mentor-card__name">Антон Михайлов</h3>
+                                <p class="mentor-card__role">Руководитель AI-направления, FinTech Corp</p>
+                                <ul class="mentor-card__list">
+                                    <li>Запустил 12 продуктов на базе больших языковых моделей</li>
+                                    <li>Сертифицированный тренер по корпоративным внедрениям</li>
+                                </ul>
+                            </div>
+                        </article>
+                        <article class="mentor-card">
+                            <img class="mentor-card__photo" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='96' height='96'%3E%3Crect width='96' height='96' rx='30' fill='%23eef2ff'/%3E%3Ctext x='48' y='62' font-size='40' text-anchor='middle' fill='%234a6fff'%3EЕ%3C/text%3E%3C/svg%3E" alt="Фото наставницы Екатерины" width="96" height="96" loading="lazy" decoding="async">
+                            <div class="mentor-card__body">
+                                <h3 class="mentor-card__name">Екатерина Власова</h3>
+                                <p class="mentor-card__role">Директор по данным, Retail Group</p>
+                                <ul class="mentor-card__list">
+                                    <li>Внедрила систему генерации отчётности для сети из 80 магазинов</li>
+                                    <li>Наставник по построению дата-команд и ML Ops</li>
+                                </ul>
+                            </div>
+                        </article>
+                        <article class="mentor-card">
+                            <img class="mentor-card__photo" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='96' height='96'%3E%3Crect width='96' height='96' rx='30' fill='%23eef2ff'/%3E%3Ctext x='48' y='62' font-size='40' text-anchor='middle' fill='%234a6fff'%3EИ%3C/text%3E%3C/svg%3E" alt="Фото наставника Игоря" width="96" height="96" loading="lazy" decoding="async">
+                            <div class="mentor-card__body">
+                                <h3 class="mentor-card__name">Игорь Сафронов</h3>
+                                <p class="mentor-card__role">Основатель студии генеративного дизайна</p>
+                                <ul class="mentor-card__list">
+                                    <li>Создаёт 3D и видео-контент для международных брендов</li>
+                                    <li>Проводит воркшопы по интеграции агентов и автоматизации</li>
+                                </ul>
+                            </div>
+                        </article>
                     </div>
                 </div>
             </section>

--- a/styles.css
+++ b/styles.css
@@ -125,6 +125,116 @@ body::after {
     flex: 1 0 auto;
 }
 
+/* Анонс с отсчетом времени */
+.announcement {
+    background: linear-gradient(90deg, rgba(79, 93, 255, 0.12) 0%, rgba(81, 208, 240, 0.18) 100%);
+    border-bottom: 1px solid rgba(79, 93, 255, 0.16);
+    box-shadow: 0 24px 60px rgba(79, 93, 255, 0.12);
+    position: relative;
+    z-index: 1100;
+}
+
+.announcement__inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 24px;
+    padding: 14px 0;
+    flex-wrap: wrap;
+}
+
+.announcement__status {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    font-weight: 600;
+    color: var(--color-secondary);
+}
+
+.announcement__dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: radial-gradient(circle, #51d0f0 0%, #4f5dff 100%);
+    box-shadow: 0 0 0 6px rgba(79, 93, 255, 0.16);
+}
+
+.announcement__timer {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 220px;
+    color: var(--color-secondary);
+}
+
+.announcement__timer-label {
+    font-size: 0.82rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    opacity: 0.8;
+}
+
+.announcement__timer-values {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.announcement__timer-values[data-countdown-ended] {
+    opacity: 0.6;
+}
+
+.announcement__time {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    padding: 10px 14px;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid rgba(79, 93, 255, 0.2);
+    box-shadow: 0 14px 30px rgba(79, 93, 255, 0.12);
+    font-weight: 700;
+    color: var(--color-primary);
+    min-width: 68px;
+    justify-content: center;
+}
+
+.announcement__time span {
+    font-size: 1.1rem;
+}
+
+.announcement__time small {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    opacity: 0.7;
+}
+
+.announcement__link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 12px 22px;
+    border-radius: 16px;
+    background: #ffffff;
+    border: 1px solid rgba(79, 93, 255, 0.24);
+    color: var(--color-secondary);
+    font-weight: 600;
+    text-decoration: none;
+    box-shadow: 0 18px 40px rgba(79, 93, 255, 0.16);
+    transition: transform var(--transition-base), box-shadow var(--transition-base), border-color var(--transition-base);
+}
+
+.announcement__link:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 24px 50px rgba(79, 93, 255, 0.2);
+    border-color: rgba(79, 93, 255, 0.36);
+}
+
+.announcement__link:focus-visible {
+    outline: 3px solid rgba(79, 93, 255, 0.4);
+    outline-offset: 4px;
+}
+
 /* Шапка сайта и меню */
 .site-header {
     position: sticky;
@@ -648,33 +758,71 @@ body::after {
 
 /* Программа интенсива */
 .program {
+    position: relative;
     display: grid;
-    gap: 24px;
+    gap: 28px;
+    counter-reset: program-step;
+    padding-left: 0;
+}
+
+.program::before {
+    content: "";
+    position: absolute;
+    top: 24px;
+    bottom: 24px;
+    left: 32px;
+    width: 2px;
+    background: linear-gradient(180deg, rgba(79, 93, 255, 0.2) 0%, rgba(81, 208, 240, 0.35) 100%);
+    pointer-events: none;
 }
 
 .program-item {
+    position: relative;
+    counter-increment: program-step;
     display: grid;
-    grid-template-columns: minmax(120px, 0.35fr) 1fr;
-    gap: 24px;
+    grid-template-columns: minmax(140px, 0.32fr) 1fr;
+    gap: 28px;
     background: linear-gradient(135deg, rgba(255, 255, 255, 0.95) 0%, rgba(220, 233, 255, 0.78) 100%);
-    border-radius: 26px;
-    padding: 28px;
+    border-radius: 28px;
+    padding: 32px 32px 32px 48px;
     border: 1px solid rgba(79, 93, 255, 0.18);
-    backdrop-filter: blur(14px);
-    box-shadow: 0 28px 60px rgba(79, 93, 255, 0.14);
+    backdrop-filter: blur(16px);
+    box-shadow: 0 32px 70px rgba(79, 93, 255, 0.16);
+}
+
+.program-item::before {
+    content: "";
+    position: absolute;
+    left: 26px;
+    top: 32px;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--gradient-accent);
+    box-shadow: 0 0 0 6px rgba(81, 208, 240, 0.25);
 }
 
 .program-item__time {
     font-weight: 700;
     color: var(--color-primary);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: 1rem;
+}
+
+.program-item__time::before {
+    content: counter(program-step);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 10px 16px;
-    border-radius: 16px;
-    background: rgba(79, 93, 255, 0.12);
-    border: 1px solid rgba(79, 93, 255, 0.2);
-    font-size: 0.95rem;
+    width: 40px;
+    height: 40px;
+    border-radius: 14px;
+    background: var(--gradient-primary);
+    color: #ffffff;
+    font-size: 1.05rem;
+    box-shadow: 0 14px 30px rgba(79, 93, 255, 0.25);
 }
 
 .program-item__title {
@@ -691,6 +839,66 @@ body::after {
     margin: 0;
     font-weight: 600;
     color: var(--color-primary);
+}
+
+/* Наставники */
+.mentor-grid {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.mentor-card {
+    display: flex;
+    gap: 20px;
+    align-items: flex-start;
+    padding: 28px;
+    border-radius: 26px;
+    background: linear-gradient(150deg, rgba(255, 255, 255, 0.95) 0%, rgba(230, 241, 255, 0.78) 100%);
+    border: 1px solid rgba(79, 93, 255, 0.18);
+    box-shadow: 0 28px 60px rgba(79, 93, 255, 0.14);
+    backdrop-filter: blur(14px);
+    transition: transform var(--transition-base), box-shadow var(--transition-base), border-color var(--transition-base);
+}
+
+.mentor-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 38px 80px rgba(79, 93, 255, 0.18);
+    border-color: rgba(79, 93, 255, 0.28);
+}
+
+.mentor-card__photo {
+    flex-shrink: 0;
+    border-radius: 28px;
+    border: 1px solid rgba(79, 93, 255, 0.2);
+    box-shadow: 0 18px 40px rgba(79, 93, 255, 0.16);
+}
+
+.mentor-card__body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.mentor-card__name {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.mentor-card__role {
+    margin: 0;
+    color: rgba(15, 23, 42, 0.68);
+    font-size: 0.95rem;
+}
+
+.mentor-card__list {
+    margin: 0;
+    padding-left: 20px;
+    color: rgba(15, 23, 42, 0.72);
+}
+
+.mentor-card__list li + li {
+    margin-top: 6px;
 }
 
 .program-extra {
@@ -1237,6 +1445,28 @@ button:focus-visible {
         width: 100%;
     }
 
+    .announcement__inner {
+        justify-content: center;
+        gap: 16px 20px;
+    }
+
+    .announcement__timer {
+        flex: 1 1 220px;
+    }
+
+    .announcement__link {
+        width: auto;
+    }
+
+    .mentor-card {
+        flex-direction: column;
+        text-align: left;
+    }
+
+    .mentor-card__photo {
+        margin: 0 auto;
+    }
+
     .program-item {
         grid-template-columns: 1fr;
     }
@@ -1261,6 +1491,29 @@ button:focus-visible {
         padding: 12px 0;
     }
 
+    .announcement__inner {
+        flex-direction: column;
+        align-items: stretch;
+        text-align: center;
+    }
+
+    .announcement__status {
+        justify-content: center;
+    }
+
+    .announcement__timer {
+        align-items: center;
+    }
+
+    .announcement__timer-values {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .announcement__link {
+        width: 100%;
+    }
+
     .btn {
         width: 100%;
     }
@@ -1282,6 +1535,36 @@ button:focus-visible {
         bottom: 20px;
         border-radius: 28px;
         width: min(100% - 24px, var(--container-width));
+    }
+
+    .program {
+        gap: 20px;
+    }
+
+    .program::before {
+        left: 20px;
+    }
+
+    .program-item {
+        padding: 26px 24px 26px 44px;
+    }
+
+    .program-item::before {
+        left: 24px;
+        top: 28px;
+    }
+
+    .program-item__time::before {
+        width: 36px;
+        height: 36px;
+    }
+
+    .mentor-card {
+        padding: 24px;
+    }
+
+    .mentor-card__photo {
+        margin: 0 auto 12px;
     }
 
     .sticky-cta {


### PR DESCRIPTION
## Summary
- add a top announcement banner with a dynamic countdown tied to the event configuration and CTA
- introduce a mentors block and enhanced timeline styling for the program section to improve perceived structure
- refresh global styles to support the new components and maintain responsive behaviour

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_6903c306c72883339668e2c3abf4c895